### PR TITLE
add conditions to use NWChem with Pynta 

### DIFF
--- a/pynta/main.py
+++ b/pynta/main.py
@@ -157,7 +157,7 @@ class Pynta:
                 run_kwargs={"fmax" : 0.01},out_path=os.path.join(self.path,"slab.xyz"),constraints=["freeze half slab"])
             wfslab = Workflow([fwslab], name=self.label+"_slab")
             self.launchpad.add_wf(wfslab)
-            self.rapidfire()
+            self.launch()
             while not os.path.exists(self.slab_path): #wait until slab optimizes, this is required anyway and makes the rest of the code simpler
                 time.sleep(1)
             self.slab = read(self.slab_path)

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -375,6 +375,8 @@ class Pynta:
                         constraints = []
                         if len(big_slab_ads) == 1 and self.software == "Espresso": #monoatomic species
                             software_kwargs["command"] = software_kwargs["command"].replace("< PREFIX.pwi > PREFIX.pwo","-ndiag 1 < PREFIX.pwi > PREFIX.pwo")
+                        if len(big_slab_ads) == 1 and self.software == "NWChem": #monoatomic species
+                            software_kwargs["command"] = software_kwargs["command"].replace("< PREFIX.nwi > PREFIX.nwo","-ndiag 1 < PREFIX.nwi > PREFIX.nwo")
                     try:
                         os.makedirs(os.path.join(self.path,"Adsorbates",adsname,str(prefix)))
                     except:
@@ -435,6 +437,8 @@ class Pynta:
                         constraints = []
                         if len(mol.atoms) == 1 and self.software == "Espresso": #monoatomic species
                             software_kwargs["command"] = software_kwargs["command"].replace("< PREFIX.pwi > PREFIX.pwo","-ndiag 1 < PREFIX.pwi > PREFIX.pwo")
+                        if len(mol.atoms) == 1 and self.software == "NWChem": #monoatomic species
+                            software_kwargs["command"] = software_kwargs["command"].replace("< PREFIX.nwi > PREFIX.nwo","-ndiag 1 < PREFIX.nwi > PREFIX.nwo")
                     else:
                         software_kwargs = deepcopy(self.software_kwargs)
                         if self.software != "XTB":

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -373,11 +373,7 @@ class Pynta:
                         constraints = []
                         if len(big_slab_ads) == 1 and self.software == "Espresso": #monoatomic species
                             software_kwargs["command"] = software_kwargs["command"].replace("< PREFIX.pwi > PREFIX.pwo","-ndiag 1 < PREFIX.pwi > PREFIX.pwo")
-<<<<<<< HEAD
-                        elif len(big_slab_ads) == 1 and self.software == "NWChem": #monoatomic species
-=======
                         if len(big_slab_ads) == 1 and self.software == "NWChem": #monoatomic species
->>>>>>> 75209f2... condition to run nwchem is added
                             software_kwargs["command"] = software_kwargs["command"].replace("< PREFIX.nwi > PREFIX.nwo","-ndiag 1 < PREFIX.nwi > PREFIX.nwo")
                     try:
                         os.makedirs(os.path.join(self.path,"Adsorbates",adsname,str(prefix)))
@@ -439,11 +435,7 @@ class Pynta:
                         constraints = []
                         if len(mol.atoms) == 1 and self.software == "Espresso": #monoatomic species
                             software_kwargs["command"] = software_kwargs["command"].replace("< PREFIX.pwi > PREFIX.pwo","-ndiag 1 < PREFIX.pwi > PREFIX.pwo")
-<<<<<<< HEAD
-                        elif len(mol.atoms) == 1 and self.software == "NWChem": #monoatomic species
-=======
                         if len(mol.atoms) == 1 and self.software == "NWChem": #monoatomic species
->>>>>>> 75209f2... condition to run nwchem is added
                             software_kwargs["command"] = software_kwargs["command"].replace("< PREFIX.nwi > PREFIX.nwo","-ndiag 1 < PREFIX.nwi > PREFIX.nwo")
                     else:
                         software_kwargs = deepcopy(self.software_kwargs)

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -31,7 +31,7 @@ class Pynta:
         lattice_opt_software_kwargs=None,
         reset_launchpad=False,queue_adapter_path=None,num_jobs=25,max_num_hfsp_opts=None,#max_num_hfsp_opts is mostly for fast testing
         Eharmtol=3.0,Eharmfiltertol=30.0,Ntsmin=5):
-
+# users need to define in input which QM software they want to use. Depending on the QM software the user define, default keywords are determined. 
         self.surface_type = surface_type
         if launchpad_path:
             launchpad = LaunchPad.from_file(launchpad_path)
@@ -54,15 +54,9 @@ class Pynta:
         self.adsorbate_fw_dict = dict()
         self.software_kwargs = software_kwargs
 
-<<<<<<< HEAD
-        if software_kwargs: 
-            self.software_kwargs = software_kwargs #use user defined keywords.
-        elif self.software == 'Espresso': #user defined keywords are not provided but if software="Espresso", use keywords below.
-=======
         if software_kwargs:
             self.software_kwargs = software_kwargs
         if self.software == 'Espresso':
->>>>>>> 75209f2... condition to run nwchem is added
             self.software_kwargs={
                 'kpts': (3, 3, 1), 
                 'tprnfor': True, 
@@ -83,7 +77,6 @@ class Pynta:
                 "C": 'C.pbe-n-kjpaw_psl.1.0.0.UPF',
                 "N": 'N.pbe-n-kjpaw_psl.1.0.0.UPF',}}
         if self.software_kwargs == 'NWChem':
->>>>>>> 75209f2... condition to run nwchem is added
             self.software_kwargs={
                 'set nwpw': 'cif_filename slab',
                 'nwpw':{'smear':'marzari-vanderbilt',
@@ -105,22 +98,14 @@ class Pynta:
 
         if software_kwargs_gas:
             self.software_kwargs_gas = software_kwargs_gas
-<<<<<<< HEAD
-        elif self.software == 'Espresso': #user defined keywords are not provided but if software="Espresso", use keywords below.
-=======
         if self.software == 'Espresso':
->>>>>>> 75209f2... condition to run nwchem is added
             self.software_kwargs_gas = deepcopy(software_kwargs)
             self.software_kwargs_gas["kpts"] = 'gamma'
             self.software_kwargs_gas["smearing"] = 'gauss'
             self.software_kwargs_gas["degauss"] = 0.005
             self.software_kwargs_gas["mixing_beta"] = 0.2
             self.software_kwargs_gas["mixing_ndim"] = 10
-<<<<<<< HEAD
-        elif self.software =='NWChem':#user defined keywords are not provided but if software="NWChem", software_kwards_gas = software_kwards
-=======
         if self.software =='NWChem':
->>>>>>> 75209f2... condition to run nwchem is added
             self.software_kwargs_gas = deepcopy(software_kwargs)
 
         self.software_kwargs_TS = deepcopy(software_kwargs)

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -24,16 +24,11 @@ import logging
 
 class Pynta:
     def __init__(self,path,rxns_file,surface_type,metal,label,launchpad_path=None,fworker_path=None,
-        vacuum=8.0,repeats=[(1,1,1),(3,3,4)],slab_path=None,software="Espresso",socket=False,queue=False,njobs_queue=0,a=None,
-        software_kwargs={'kpts': (3, 3, 1), 'tprnfor': True, 'occupations': 'smearing',
-                            'smearing':  'marzari-vanderbilt',
-                            'degauss': 0.01, 'ecutwfc': 40, 'nosym': True,
-                            'conv_thr': 1e-6, 'mixing_mode': 'local-TF',
-                            "pseudopotentials": {"Cu": 'Cu.pbe-spn-kjpaw_psl.1.0.0.UPF',"H": 'H.pbe-kjpaw_psl.1.0.0.UPF',"O": 'O.pbe-n-kjpaw_psl.1.0.0.UPF',"C": 'C.pbe-n-kjpaw_psl.1.0.0.UPF',"N": 'N.pbe-n-kjpaw_psl.1.0.0.UPF',
-                            }, },
+        vacuum=8.0,repeats=[(1,1,1),(3,3,4)],slab_path=None,software=None,socket=False,queue=False,njobs_queue=0,a=None,
+        software_kwargs=None,
         software_kwargs_gas=None,
         TS_opt_software_kwargs=None,
-        lattice_opt_software_kwargs={'kpts': (25,25,25), 'ecutwfc': 70, 'degauss':0.02, 'mixing_mode': 'plain'},
+        lattice_opt_software_kwargs=None,
         reset_launchpad=False,queue_adapter_path=None,num_jobs=25,max_num_hfsp_opts=None,#max_num_hfsp_opts is mostly for fast testing
         Eharmtol=3.0,Eharmfiltertol=30.0,Ntsmin=5):
 
@@ -59,15 +54,47 @@ class Pynta:
         self.adsorbate_fw_dict = dict()
         self.software_kwargs = software_kwargs
 
+        if software_kwargs: 
+            self.software_kwargs = software_kwargs #use user defined keywords.
+        elif self.software == 'Espresso': #user defined keywords are not provided but if software="Espresso", use keywords below.
+            self.software_kwargs={
+                'kpts': (3, 3, 1), 
+                'tprnfor': True, 
+                'occupations': 'smearing',
+                'smearing':  'marzari-vanderbilt',
+                'degauss': 0.01, 
+                'ecutwfc': 40, 
+                'nosym': True,
+                'conv_thr': 1e-6, 
+                'mixing_mode': 'local-TF',
+                "pseudopotentials": {"Cu": 'Cu.pbe-spn-kjpaw_psl.1.0.0.UPF'}}
+        elif self.software_kwargs == 'NWChem': #user defined keywords are not provided but if software="NWChem", use keywords below.
+            self.software_kwargs={
+                'set nwpw': 'cif_filename slab',
+                'nwpw':{'smear':'marzari-vanderbilt',
+                        'ewald_ncut': 10,
+                        'ewald_rcut': 3.0,
+                        'xc':'beef-vdw',
+                        'kpts':(3,3,2),
+                        'loop':'10,10',
+                        'cutoff':20.0},
+                'nwpw':{
+                        'pseudopotentials':'Cu library pspw_default',
+                        '':'end'},
+                'set':{'nwpw:kbpp_ray': True,
+                        'nwpw:kbpp_filter': True}}
+
         if software_kwargs_gas:
             self.software_kwargs_gas = software_kwargs_gas
-        else:
+        elif self.software == 'Espresso': #user defined keywords are not provided but if software="Espresso", use keywords below.
             self.software_kwargs_gas = deepcopy(software_kwargs)
             self.software_kwargs_gas["kpts"] = 'gamma'
             self.software_kwargs_gas["smearing"] = 'gauss'
             self.software_kwargs_gas["degauss"] = 0.005
             self.software_kwargs_gas["mixing_beta"] = 0.2
             self.software_kwargs_gas["mixing_ndim"] = 10
+        elif self.software =='NWChem':#user defined keywords are not provided but if software="NWChem", software_kwards_gas = software_kwards
+            self.software_kwargs_gas = deepcopy(software_kwargs)
 
         self.software_kwargs_TS = deepcopy(software_kwargs)
         if TS_opt_software_kwargs:
@@ -336,6 +363,8 @@ class Pynta:
                         constraints = []
                         if len(big_slab_ads) == 1 and self.software == "Espresso": #monoatomic species
                             software_kwargs["command"] = software_kwargs["command"].replace("< PREFIX.pwi > PREFIX.pwo","-ndiag 1 < PREFIX.pwi > PREFIX.pwo")
+                        elif len(big_slab_ads) == 1 and self.software == "NWChem": #monoatomic species
+                            software_kwargs["command"] = software_kwargs["command"].replace("< PREFIX.nwi > PREFIX.nwo","-ndiag 1 < PREFIX.nwi > PREFIX.nwo")
                     try:
                         os.makedirs(os.path.join(self.path,"Adsorbates",adsname,str(prefix)))
                     except:
@@ -396,6 +425,8 @@ class Pynta:
                         constraints = []
                         if len(mol.atoms) == 1 and self.software == "Espresso": #monoatomic species
                             software_kwargs["command"] = software_kwargs["command"].replace("< PREFIX.pwi > PREFIX.pwo","-ndiag 1 < PREFIX.pwi > PREFIX.pwo")
+                        elif len(mol.atoms) == 1 and self.software == "NWChem": #monoatomic species
+                            software_kwargs["command"] = software_kwargs["command"].replace("< PREFIX.nwi > PREFIX.nwo","-ndiag 1 < PREFIX.nwi > PREFIX.nwo")
                     else:
                         software_kwargs = deepcopy(self.software_kwargs)
                         if self.software != "XTB":

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -36,6 +36,7 @@ class Pynta:
         lattice_opt_software_kwargs={'kpts': (25,25,25), 'ecutwfc': 70, 'degauss':0.02, 'mixing_mode': 'plain'},
         reset_launchpad=False,queue_adapter_path=None,num_jobs=25,max_num_hfsp_opts=None,#max_num_hfsp_opts is mostly for fast testing
         Eharmtol=3.0,Eharmfiltertol=30.0,Ntsmin=5):
+
         self.surface_type = surface_type
         if launchpad_path:
             launchpad = LaunchPad.from_file(launchpad_path)
@@ -58,15 +59,51 @@ class Pynta:
         self.adsorbate_fw_dict = dict()
         self.software_kwargs = software_kwargs
 
+        if software_kwargs:
+            self.software_kwargs = software_kwargs
+        if self.software == 'Espresso':
+            self.software_kwargs={
+                'kpts': (3, 3, 1), 
+                'tprnfor': True, 
+                'occupations': 'smearing',
+                'smearing':  'marzari-vanderbilt',
+                'degauss': 0.01, 
+                'ecutwfc': 40, 
+                'nosym': True,
+                'conv_thr': 1e-6, 
+                'mixing_mode': 'local-TF',
+                "pseudopotentials": {"Cu": 'Cu.pbe-spn-kjpaw_psl.1.0.0.UPF',
+                "H": 'H.pbe-kjpaw_psl.1.0.0.UPF',
+                "O": 'O.pbe-n-kjpaw_psl.1.0.0.UPF',
+                "C": 'C.pbe-n-kjpaw_psl.1.0.0.UPF',
+                "N": 'N.pbe-n-kjpaw_psl.1.0.0.UPF',}}
+        if self.software_kwargs == 'NWChem':
+            self.software_kwargs={
+                'set nwpw': 'cif_filename slab',
+                'nwpw':{'smear':'marzari-vanderbilt',
+                        'ewald_ncut': 10,
+                        'ewald_rcut': 3.0,
+                        'xc':'beef-vdw',
+                        'kpts':(3,3,2),
+                        'loop':'10,10',
+                        'cutoff':20.0},
+                'nwpw':{
+                        'pseudopotentials':'Cu library paw_default',
+                        '':'end'},
+                'set':{'nwpw:kbpp_ray': True,
+                        'nwpw:kbpp_filter': True}}
+
         if software_kwargs_gas:
             self.software_kwargs_gas = software_kwargs_gas
-        else:
+        if self.software == 'Espresso':
             self.software_kwargs_gas = deepcopy(software_kwargs)
             self.software_kwargs_gas["kpts"] = 'gamma'
             self.software_kwargs_gas["smearing"] = 'gauss'
             self.software_kwargs_gas["degauss"] = 0.005
             self.software_kwargs_gas["mixing_beta"] = 0.2
             self.software_kwargs_gas["mixing_ndim"] = 10
+        if self.software =='NWChem':
+            self.software_kwargs_gas = deepcopy(software_kwargs)
 
         self.software_kwargs_TS = deepcopy(software_kwargs)
         if TS_opt_software_kwargs:

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -53,9 +53,9 @@ class Pynta:
         self.adsorbate_fw_dict = dict()
         self.software_kwargs = software_kwargs
 
-        if software_kwargs:
-            self.software_kwargs = software_kwargs
-        if self.software == 'Espresso':
+        if software_kwargs: 
+            self.software_kwargs = software_kwargs #use user defined keywords.
+        if self.software == 'Espresso': #user defined keywords are not provided but if software="Espresso", use keywords below.
             self.software_kwargs={
                 'kpts': (3, 3, 1), 
                 'tprnfor': True, 
@@ -66,16 +66,12 @@ class Pynta:
                 'nosym': True,
                 'conv_thr': 1e-6, 
                 'mixing_mode': 'local-TF',
-<<<<<<< HEAD
-                "pseudopotentials": {"Cu": 'Cu.pbe-spn-kjpaw_psl.1.0.0.UPF'}}
-        elif self.software_kwargs == 'NWChem': #user defined keywords are not provided but if software="NWChem", use keywords below.
-=======
                 "pseudopotentials": {"Cu": 'Cu.pbe-spn-kjpaw_psl.1.0.0.UPF',
                 "H": 'H.pbe-kjpaw_psl.1.0.0.UPF',
                 "O": 'O.pbe-n-kjpaw_psl.1.0.0.UPF',
                 "C": 'C.pbe-n-kjpaw_psl.1.0.0.UPF',
                 "N": 'N.pbe-n-kjpaw_psl.1.0.0.UPF',}}
-        if self.software_kwargs == 'NWChem':
+        if self.software_kwargs == 'NWChem': #user defined keywords are not provided but if software="NWChem", use keywords below.
             self.software_kwargs={
                 'set nwpw': 'cif_filename slab',
                 'nwpw':{'smear':'marzari-vanderbilt',
@@ -97,15 +93,18 @@ class Pynta:
 
         if software_kwargs_gas:
             self.software_kwargs_gas = software_kwargs_gas
-        if self.software == 'Espresso':
+        if self.software == 'Espresso': #user defined keywords are not provided but if software="Espresso", use keywords below.
             self.software_kwargs_gas = deepcopy(software_kwargs)
             self.software_kwargs_gas["kpts"] = 'gamma'
             self.software_kwargs_gas["smearing"] = 'gauss'
             self.software_kwargs_gas["degauss"] = 0.005
             self.software_kwargs_gas["mixing_beta"] = 0.2
             self.software_kwargs_gas["mixing_ndim"] = 10
-        if self.software =='NWChem':
+        if self.software =='NWChem':#user defined keywords are not provided but if software="NWChem", software_kwards_gas = software_kwards
             self.software_kwargs_gas = deepcopy(software_kwargs)
+        
+        else:
+            print("software_kwargs_gas are not defined. Please provide software keywords in the input")
 
         self.software_kwargs_TS = deepcopy(software_kwargs)
         if TS_opt_software_kwargs:
@@ -540,33 +539,17 @@ class Pynta:
             generate_initial_ad_guesses = False
 
         if self.slab_path is None: #handle slab
-            print("if self.generate_slab()")
             self.generate_slab()
 
-        print("self.analyze_slab()")
         self.analyze_slab()
-        print("self.generate_mole_dict()")
         self.generate_mol_dict()
-<<<<<<< HEAD
-        self.generate_initial_adsorbate_guesses(skip_structs=(not generate_initial_ad_guesses))
-
-        #adsorbate optimization
-        if calculate_adsorbates:
-            self.setup_adsorbates(initial_guess_finished=(not generate_initial_ad_guesses))
-
-        if calculate_transition_states:
-            #setup transition states
-            self.setup_transition_states(adsorbates_finished=(not calculate_adsorbates))
-=======
         print("self.generate_initial_absorbate_guesses()")
         self.generate_initial_adsorbate_guesses()
 
         #adsorbate optimization
-        print("self.setup_adsorbate")
         self.setup_adsorbates()
 
         #setup transition states
-        print("self.setup_transition_states()")
         self.setup_transition_states()
 >>>>>>> 75209f2... condition to run nwchem is added
 

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -31,7 +31,6 @@ class Pynta:
         lattice_opt_software_kwargs=None,
         reset_launchpad=False,queue_adapter_path=None,num_jobs=25,max_num_hfsp_opts=None,#max_num_hfsp_opts is mostly for fast testing
         Eharmtol=3.0,Eharmfiltertol=30.0,Ntsmin=5):
-# users need to define in input which QM software they want to use. Depending on the QM software the user define, default keywords are determined. 
         self.surface_type = surface_type
         if launchpad_path:
             launchpad = LaunchPad.from_file(launchpad_path)

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -104,9 +104,6 @@ class Pynta:
             self.software_kwargs_gas["mixing_ndim"] = 10
         if self.software =='NWChem':#user defined keywords are not provided but if software="NWChem", software_kwards_gas = software_kwards
             self.software_kwargs_gas = deepcopy(software_kwargs)
-        
-        else:
-            print("software_kwargs_gas are not defined. Please provide software keywords in the input")
 
         self.software_kwargs_TS = deepcopy(software_kwargs)
         if TS_opt_software_kwargs:

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -82,11 +82,7 @@ class Pynta:
                         'loop':'10,10',
                         'cutoff':20.0},
                 'nwpw':{
-<<<<<<< HEAD
-                        'pseudopotentials':'Cu library pspw_default',
-=======
                         'pseudopotentials':'Cu library paw_default',
->>>>>>> 75209f2... condition to run nwchem is added
                         '':'end'},
                 'set':{'nwpw:kbpp_ray': True,
                         'nwpw:kbpp_filter': True}}

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -160,7 +160,7 @@ class Pynta:
                 run_kwargs={"fmax" : 0.01},out_path=os.path.join(self.path,"slab.xyz"),constraints=["freeze half slab"])
             wfslab = Workflow([fwslab], name=self.label+"_slab")
             self.launchpad.add_wf(wfslab)
-            self.launch()
+            self.launch()#            self.rapidfire()
             while not os.path.exists(self.slab_path): #wait until slab optimizes, this is required anyway and makes the rest of the code simpler
                 time.sleep(1)
             self.slab = read(self.slab_path)

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -88,7 +88,7 @@ class Pynta:
                         'loop':'10,10',
                         'cutoff':20.0},
                 'nwpw':{
-                        'pseudopotentials':'Cu library paw_default',
+                        'pseudopotentials':'Cu library pspw_default',
                         '':'end'},
                 'set':{'nwpw:kbpp_ray': True,
                         'nwpw:kbpp_filter': True}}

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -54,9 +54,15 @@ class Pynta:
         self.adsorbate_fw_dict = dict()
         self.software_kwargs = software_kwargs
 
+<<<<<<< HEAD
         if software_kwargs: 
             self.software_kwargs = software_kwargs #use user defined keywords.
         elif self.software == 'Espresso': #user defined keywords are not provided but if software="Espresso", use keywords below.
+=======
+        if software_kwargs:
+            self.software_kwargs = software_kwargs
+        if self.software == 'Espresso':
+>>>>>>> 75209f2... condition to run nwchem is added
             self.software_kwargs={
                 'kpts': (3, 3, 1), 
                 'tprnfor': True, 
@@ -67,8 +73,17 @@ class Pynta:
                 'nosym': True,
                 'conv_thr': 1e-6, 
                 'mixing_mode': 'local-TF',
+<<<<<<< HEAD
                 "pseudopotentials": {"Cu": 'Cu.pbe-spn-kjpaw_psl.1.0.0.UPF'}}
         elif self.software_kwargs == 'NWChem': #user defined keywords are not provided but if software="NWChem", use keywords below.
+=======
+                "pseudopotentials": {"Cu": 'Cu.pbe-spn-kjpaw_psl.1.0.0.UPF',
+                "H": 'H.pbe-kjpaw_psl.1.0.0.UPF',
+                "O": 'O.pbe-n-kjpaw_psl.1.0.0.UPF',
+                "C": 'C.pbe-n-kjpaw_psl.1.0.0.UPF',
+                "N": 'N.pbe-n-kjpaw_psl.1.0.0.UPF',}}
+        if self.software_kwargs == 'NWChem':
+>>>>>>> 75209f2... condition to run nwchem is added
             self.software_kwargs={
                 'set nwpw': 'cif_filename slab',
                 'nwpw':{'smear':'marzari-vanderbilt',
@@ -79,21 +94,33 @@ class Pynta:
                         'loop':'10,10',
                         'cutoff':20.0},
                 'nwpw':{
+<<<<<<< HEAD
                         'pseudopotentials':'Cu library pspw_default',
+=======
+                        'pseudopotentials':'Cu library paw_default',
+>>>>>>> 75209f2... condition to run nwchem is added
                         '':'end'},
                 'set':{'nwpw:kbpp_ray': True,
                         'nwpw:kbpp_filter': True}}
 
         if software_kwargs_gas:
             self.software_kwargs_gas = software_kwargs_gas
+<<<<<<< HEAD
         elif self.software == 'Espresso': #user defined keywords are not provided but if software="Espresso", use keywords below.
+=======
+        if self.software == 'Espresso':
+>>>>>>> 75209f2... condition to run nwchem is added
             self.software_kwargs_gas = deepcopy(software_kwargs)
             self.software_kwargs_gas["kpts"] = 'gamma'
             self.software_kwargs_gas["smearing"] = 'gauss'
             self.software_kwargs_gas["degauss"] = 0.005
             self.software_kwargs_gas["mixing_beta"] = 0.2
             self.software_kwargs_gas["mixing_ndim"] = 10
+<<<<<<< HEAD
         elif self.software =='NWChem':#user defined keywords are not provided but if software="NWChem", software_kwards_gas = software_kwards
+=======
+        if self.software =='NWChem':
+>>>>>>> 75209f2... condition to run nwchem is added
             self.software_kwargs_gas = deepcopy(software_kwargs)
 
         self.software_kwargs_TS = deepcopy(software_kwargs)
@@ -363,7 +390,11 @@ class Pynta:
                         constraints = []
                         if len(big_slab_ads) == 1 and self.software == "Espresso": #monoatomic species
                             software_kwargs["command"] = software_kwargs["command"].replace("< PREFIX.pwi > PREFIX.pwo","-ndiag 1 < PREFIX.pwi > PREFIX.pwo")
+<<<<<<< HEAD
                         elif len(big_slab_ads) == 1 and self.software == "NWChem": #monoatomic species
+=======
+                        if len(big_slab_ads) == 1 and self.software == "NWChem": #monoatomic species
+>>>>>>> 75209f2... condition to run nwchem is added
                             software_kwargs["command"] = software_kwargs["command"].replace("< PREFIX.nwi > PREFIX.nwo","-ndiag 1 < PREFIX.nwi > PREFIX.nwo")
                     try:
                         os.makedirs(os.path.join(self.path,"Adsorbates",adsname,str(prefix)))
@@ -425,7 +456,11 @@ class Pynta:
                         constraints = []
                         if len(mol.atoms) == 1 and self.software == "Espresso": #monoatomic species
                             software_kwargs["command"] = software_kwargs["command"].replace("< PREFIX.pwi > PREFIX.pwo","-ndiag 1 < PREFIX.pwi > PREFIX.pwo")
+<<<<<<< HEAD
                         elif len(mol.atoms) == 1 and self.software == "NWChem": #monoatomic species
+=======
+                        if len(mol.atoms) == 1 and self.software == "NWChem": #monoatomic species
+>>>>>>> 75209f2... condition to run nwchem is added
                             software_kwargs["command"] = software_kwargs["command"].replace("< PREFIX.nwi > PREFIX.nwo","-ndiag 1 < PREFIX.nwi > PREFIX.nwo")
                     else:
                         software_kwargs = deepcopy(self.software_kwargs)
@@ -521,10 +556,14 @@ class Pynta:
             generate_initial_ad_guesses = False
 
         if self.slab_path is None: #handle slab
+            print("if self.generate_slab()")
             self.generate_slab()
 
+        print("self.analyze_slab()")
         self.analyze_slab()
+        print("self.generate_mole_dict()")
         self.generate_mol_dict()
+<<<<<<< HEAD
         self.generate_initial_adsorbate_guesses(skip_structs=(not generate_initial_ad_guesses))
 
         #adsorbate optimization
@@ -534,13 +573,24 @@ class Pynta:
         if calculate_transition_states:
             #setup transition states
             self.setup_transition_states(adsorbates_finished=(not calculate_adsorbates))
+=======
+        print("self.generate_initial_absorbate_guesses()")
+        self.generate_initial_adsorbate_guesses()
+
+        #adsorbate optimization
+        print("self.setup_adsorbate")
+        self.setup_adsorbates()
+
+        #setup transition states
+        print("self.setup_transition_states()")
+        self.setup_transition_states()
+>>>>>>> 75209f2... condition to run nwchem is added
 
         wf = Workflow(self.fws, name=self.label)
         self.launchpad.add_wf(wf)
 
         if launch:
             self.launch()
-
 
     def execute_from_initial_ad_guesses(self):
         if self.slab_path is None: #handle slab

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -98,9 +98,6 @@ class Pynta:
             self.software_kwargs_gas["mixing_ndim"] = 10
         if self.software =='NWChem':#user defined keywords are not provided but if software="NWChem", software_kwards_gas = software_kwards
             self.software_kwargs_gas = deepcopy(software_kwargs)
-        
-        else:
-            print("software_kwargs_gas are not defined. Please provide software keywords in the input")
 
         self.software_kwargs_TS = deepcopy(software_kwargs)
         if TS_opt_software_kwargs:

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -59,9 +59,9 @@ class Pynta:
         self.adsorbate_fw_dict = dict()
         self.software_kwargs = software_kwargs
 
-        if software_kwargs:
-            self.software_kwargs = software_kwargs
-        if self.software == 'Espresso':
+        if software_kwargs: 
+            self.software_kwargs = software_kwargs #use user defined keywords.
+        if self.software == 'Espresso': #user defined keywords are not provided but if software="Espresso", use keywords below.
             self.software_kwargs={
                 'kpts': (3, 3, 1), 
                 'tprnfor': True, 
@@ -77,7 +77,7 @@ class Pynta:
                 "O": 'O.pbe-n-kjpaw_psl.1.0.0.UPF',
                 "C": 'C.pbe-n-kjpaw_psl.1.0.0.UPF',
                 "N": 'N.pbe-n-kjpaw_psl.1.0.0.UPF',}}
-        if self.software_kwargs == 'NWChem':
+        if self.software_kwargs == 'NWChem': #user defined keywords are not provided but if software="NWChem", use keywords below.
             self.software_kwargs={
                 'set nwpw': 'cif_filename slab',
                 'nwpw':{'smear':'marzari-vanderbilt',
@@ -95,15 +95,18 @@ class Pynta:
 
         if software_kwargs_gas:
             self.software_kwargs_gas = software_kwargs_gas
-        if self.software == 'Espresso':
+        if self.software == 'Espresso': #user defined keywords are not provided but if software="Espresso", use keywords below.
             self.software_kwargs_gas = deepcopy(software_kwargs)
             self.software_kwargs_gas["kpts"] = 'gamma'
             self.software_kwargs_gas["smearing"] = 'gauss'
             self.software_kwargs_gas["degauss"] = 0.005
             self.software_kwargs_gas["mixing_beta"] = 0.2
             self.software_kwargs_gas["mixing_ndim"] = 10
-        if self.software =='NWChem':
+        if self.software =='NWChem':#user defined keywords are not provided but if software="NWChem", software_kwards_gas = software_kwards
             self.software_kwargs_gas = deepcopy(software_kwargs)
+        
+        else:
+            print("software_kwargs_gas are not defined. Please provide software keywords in the input")
 
         self.software_kwargs_TS = deepcopy(software_kwargs)
         if TS_opt_software_kwargs:
@@ -526,21 +529,17 @@ class Pynta:
             generate_initial_ad_guesses = False
 
         if self.slab_path is None: #handle slab
-            print("if self.generate_slab()")
             self.generate_slab()
 
-        print("self.analyze_slab()")
         self.analyze_slab()
-        print("self.generate_mole_dict()")
         self.generate_mol_dict()
+        print("self.generate_initial_absorbate_guesses()")
         self.generate_initial_adsorbate_guesses()
 
         #adsorbate optimization
-        print("self.setup_adsorbate")
         self.setup_adsorbates()
 
         #setup transition states
-        print("self.setup_transition_states()")
         self.setup_transition_states()
 >>>>>>> 75209f2... condition to run nwchem is added
 


### PR DESCRIPTION
- Previously: Pynta uses QE as a default QM software. In main.py, the keywords in `__init__` are input keywords for QE.
- Modification: Keywords in __init__ are now all user-defined. In the input, user needs to define which QM software they want to use. (i.e. software = "NWChem"). Depending on the QM software that users define to use, pre-determined keywords ( `software_kwargs`) are also provided in Main.py accordingly. 

- Comments: Sample Pynta input with NWChem is attached. 

----------------------------------------------------------------------------------------------------------------------------
#this is a sample input for running nwchem. Notice that `software="NWChem"` is added. 

from pynta.main import Pynta
import sys
print(sys.prefix)

pyn = Pynta(path="/where/you/run/pynta/job",launchpad_path="/dir/to/your/my_launchpad.yaml",
        fworker_path="/dir/to/your/my_fworker.yaml",
        queue_adapter_path="/dir/to/your/my_qadapter.yaml",
        rxns_file="/dir/to/your/reaction.yaml",
                surface_type="fcc111",metal="Cu",`software="NWChem"`,socket=False,queue=True,njobs_queue=5,
        repeats=[(1,1,1),(3,3,4)],label="pynta-nwchem",
        
software_kwargs={'set nwpw': 'cif_filename debug',
                         'nwpw':{'smear':'marzari-vanderbilt',
                                  'ewald_ncut': 10,
                                  'ewald_rcut': 3.0,
                                  'xc':'beef-vdw',
                                  'loop':'10 10',
                                  'cutoff':10.0},
                                  'nwpw':{'pseudopotentials':'Cu library paw_default',
                                  '':'end'},
                            'set':{'nwpw:kbpp_ray': True,
                              'nwpw:kbpp_filter': True},
                "command": f'/script/to/run/nwchem  PREFIX.nwi PREFIX.nwo'},
        
software_kwargs_gas={'set nwpw': 'cif_filename debug',
                             'nwpw':{'smear':'marzari-vanderbilt',
                                  'ewald_ncut': 10,
                                  'ewald_rcut': 3.0,
                                  'xc':'beef-vdw',
                                  'kpts':(3,3,1),
                                  'loop': '10 10',
                                  'cutoff':10.0,
                                  'nwpw':{'pseudopotentials':'Cu library paw_default',
                                  '':'end'},
                                  },
                             'set':{'nwpw:kbpp_ray': True,
                                    'nwpw:kbpp_filter': True},
                "command": f'/script/to/run/nwchem  PREFIX.nwi PREFIX.nwo'},
        
TS_opt_software_kwargs=None,
        
lattice_opt_software_kwargs={'kpts': (3,3,1),
                                  'nwpw':{'pseudopotentials':'Cu library paw_default',
                                  '':'end'},
                              'set':{'nwpw:kbpp_ray': True,
                              'nwpw:kbpp_filter': True},
                "command": f'/script/to/run/nwchem  PREFIX.nwi PREFIX.nwo'},

slab_path = "/dir/to/your/slab.xyz",)
pyn.execute()
