### PR TITLE
Update calculator.py

### DIFF
--- a/pynta/calculator.py
+++ b/pynta/calculator.py
@@ -285,7 +285,7 @@ def run_harmonically_forced_xtb_no_pbc(atoms,atom_bond_potentials,site_bond_pote
     hfxtb = HarmonicallyForcedXTB(method="GFN1-xTB",
                                   atom_bond_potentials=new_atom_bond_potentials,
                                  site_bond_potentials=new_site_potentials)
-
+    bigad.set_constraint(out_constraints)
     bigad.calc = hfxtb
 
     opt = Sella(bigad,trajectory="xtbharm.traj",order=0)


### PR DESCRIPTION
Adding a fix to run_harmonically_forced_xtb_no_pbc function. Needed to apply the new_constraints to the bigad atom object. Test shows adsorbate is now properly constrained.