### PR TITLE
Machine keyword added to chose which machine to run Pynta 

### DIFF
--- a/pynta/main.py
+++ b/pynta/main.py
@@ -24,7 +24,7 @@ import logging
 
 class Pynta:
     def __init__(self,path,rxns_file,surface_type,metal,label,launchpad_path=None,fworker_path=None,
-        vacuum=8.0,repeats=(3,3,4),slab_path=None,software="Espresso",socket=False,queue=False,njobs_queue=0,a=None,
+        vacuum=8.0,repeats=(3,3,4),slab_path=None,software="Espresso",machine="linux64",socket=False,queue=False,njobs_queue=0,a=None,
         software_kwargs={'kpts': (3, 3, 1), 'tprnfor': True, 'occupations': 'smearing',
                             'smearing':  'marzari-vanderbilt',
                             'degauss': 0.01, 'ecutwfc': 40, 'nosym': True,
@@ -50,6 +50,7 @@ class Pynta:
         self.vacuum = vacuum
         self.a = a
         self.software = software
+        self.machine = machine #define which machine you are using
         self.socket = socket
         self.repeats = repeats
         self.path = os.getcwd() if path is None else path

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -412,7 +412,7 @@ class Pynta:
                         run_kwargs={"fmax" : 0.5, "steps" : 70},parents=[],constraints=constraints,
                         ignore_errors=True, metal=self.metal, facet=self.surface_type, target_site_num=target_site_num, priority=3)
                     fwopt2 = optimize_firework(os.path.join(self.path,"Adsorbates",ad,str(prefix),"weakopt_"+str(prefix)+".xyz"),
-                        self.software,str(prefix),
+                        self.software,str(prefix),self.machine,
                         opt_method="QuasiNewton",socket=self.socket,software_kwargs=software_kwargs,
                         run_kwargs={"fmax" : self.fmaxopt, "steps" : 70},parents=[fwopt],constraints=constraints,
                         ignore_errors=True, metal=self.metal, facet=self.surface_type, target_site_num=target_site_num, priority=3)

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -435,10 +435,10 @@ class Pynta:
         Note the vibrational and IRC calculations are launched at the same time
         """
         if self.software != "XTB":
-            opt_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs_TS,
+            opt_obj_dict = {"software":self.software,"label":"prefix","machine":self.machine,"socket":self.socket,"software_kwargs":self.software_kwargs_TS,
                 "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)],"sella":True,"order":1,}
         else:
-            opt_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs_TS,
+            opt_obj_dict = {"software":self.software,"label":"prefix","machine":self.machine,"socket":self.socket,"software_kwargs":self.software_kwargs_TS,
                 "run_kwargs": {"fmax" : 0.02, "steps" : 70},"constraints": ["freeze up to "+str(self.nslab)],"sella":True,"order":1,}
         vib_obj_dict = {"software":self.software,"label":"prefix", "machine":self.machine, "socket":self.socket,"software_kwargs":self.software_kwargs,
                 "constraints": ["freeze up to "+str(self.nslab)]}

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -132,7 +132,7 @@ class Pynta:
         write(os.path.join(self.path,"slab_init.xyz"),slab)
         self.slab_path = os.path.join(self.path,"slab.xyz")
         if self.software != "XTB":
-            fwslab = optimize_firework(os.path.join(self.path,"slab_init.xyz"),self.software,"slab",
+            fwslab = optimize_firework(os.path.join(self.path,"slab_init.xyz"),self.software,"slab",self.machine,
                 opt_method="BFGSLineSearch",socket=self.socket,software_kwargs=self.software_kwargs,
                 run_kwargs={"fmax" : self.fmaxopt},out_path=os.path.join(self.path,"slab.xyz"),constraints=["freeze up to {}".format(self.freeze_ind)],priority=1000)
             wfslab = Workflow([fwslab], name=self.label+"_slab")

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -24,7 +24,7 @@ import logging
 
 class Pynta:
     def __init__(self,path,rxns_file,surface_type,metal,label,launchpad_path=None,fworker_path=None,
-        vacuum=8.0,repeats=(3,3,4),slab_path=None,software="Espresso",machine="linux64",socket=False,queue=False,njobs_queue=0,a=None,
+        vacuum=8.0,repeats=(3,3,4),slab_path=None,software="Espresso",machine=None,socket=False,queue=False,njobs_queue=0,a=None,
         software_kwargs={'kpts': (3, 3, 1), 'tprnfor': True, 'occupations': 'smearing',
                             'smearing':  'marzari-vanderbilt',
                             'degauss': 0.01, 'ecutwfc': 40, 'nosym': True,

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -420,7 +420,7 @@ class Pynta:
                     optfws.append(fwopt2)
                     optfws2.append(fwopt2)
 
-                vib_obj_dict = {"software": self.software, "label": ad, "software_kwargs": software_kwargs,
+                vib_obj_dict = {"software": self.software, "label": ad, "machine":self.machine, "software_kwargs": software_kwargs,
                     "constraints": ["freeze up to "+str(self.nslab)]}
 
                 cfw = collect_firework(xyzs,True,["vibrations_firework"],[vib_obj_dict],["vib.json"],[True,False],parents=optfws2,label=ad,allow_fizzled_parents=False)

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -440,7 +440,7 @@ class Pynta:
         else:
             opt_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs_TS,
                 "run_kwargs": {"fmax" : 0.02, "steps" : 70},"constraints": ["freeze up to "+str(self.nslab)],"sella":True,"order":1,}
-        vib_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
+        vib_obj_dict = {"software":self.software,"label":"prefix", "machine":self.machine, "socket":self.socket,"software_kwargs":self.software_kwargs,
                 "constraints": ["freeze up to "+str(self.nslab)]}
         IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
                 "run_kwargs": {"fmax" : self.fmaxirc, "steps" : 70},"constraints":["freeze up to "+str(self.nslab)]}

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -412,7 +412,7 @@ class Pynta:
                         run_kwargs={"fmax" : 0.5, "steps" : 70},parents=[],constraints=constraints,
                         ignore_errors=True, metal=self.metal, facet=self.surface_type, target_site_num=target_site_num, priority=3)
                     fwopt2 = optimize_firework(os.path.join(self.path,"Adsorbates",ad,str(prefix),"weakopt_"+str(prefix)+".xyz"),
-                        self.software,self.machine,str(prefix),
+                        self.software,str(prefix),
                         opt_method="QuasiNewton",socket=self.socket,software_kwargs=software_kwargs,
                         run_kwargs={"fmax" : self.fmaxopt, "steps" : 70},parents=[fwopt],constraints=constraints,
                         ignore_errors=True, metal=self.metal, facet=self.surface_type, target_site_num=target_site_num, priority=3)

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -407,12 +407,12 @@ class Pynta:
                     assert os.path.exists(init_path), init_path
                     xyzs.append(xyz)
                     fwopt = optimize_firework(init_path,
-                        self.software,"weakopt_"+str(prefix),
+                        self.software,"weakopt_"+str(prefix),self.machine,
                         opt_method="MDMin",opt_kwargs={'dt': 0.05},socket=self.socket,software_kwargs=software_kwargs,
                         run_kwargs={"fmax" : 0.5, "steps" : 70},parents=[],constraints=constraints,
                         ignore_errors=True, metal=self.metal, facet=self.surface_type, target_site_num=target_site_num, priority=3)
                     fwopt2 = optimize_firework(os.path.join(self.path,"Adsorbates",ad,str(prefix),"weakopt_"+str(prefix)+".xyz"),
-                        self.software,str(prefix),
+                        self.software,self.machine,str(prefix),
                         opt_method="QuasiNewton",socket=self.socket,software_kwargs=software_kwargs,
                         run_kwargs={"fmax" : self.fmaxopt, "steps" : 70},parents=[fwopt],constraints=constraints,
                         ignore_errors=True, metal=self.metal, facet=self.surface_type, target_site_num=target_site_num, priority=3)

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -685,6 +685,7 @@ class MolecularCollect(CollectTask):
                 d["out_path"] = os.path.join(os.path.split(xyz)[0],out_names[0][i])
                 d["label"] = out_names[0][i]
                 d["ignore_errors"] = True
+                d["machine"] = machine
                 out_xyzs.append(d["out_path"])
                 fw = fw_generator(**d)
                 if not isinstance(fw,list):

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -374,7 +374,7 @@ class MolecularEnergyTask(EnergyTask):
         return FWAction()
 
 def vibrations_firework(xyz,software,label,machine,software_kwargs={},parents=[],out_path=None,constraints=[],socket=False,ignore_errors=False):
-    d = {"xyz" : xyz, "software" : software, "label" : label, "socket": socket}
+    d = {"xyz" : xyz, "software" : software, "label" : label, "socket": socket, "machine":machine}
     if machine == "polaris":
         if software == "Espresso":
             node = MapTaskToNodes()

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -65,8 +65,8 @@ def optimize_firework(xyz,software,label,machine,opt_method=None,sella=None,sock
             node = MapTaskToNodes()
             newcommand = node.getCommand()
             software_kwargs["command"] = newcommand
-    else:
-        continue
+        else:
+            continue
     if opt_method: d["opt_method"] = opt_method
     if software_kwargs: d["software_kwargs"] = software_kwargs
     if opt_kwargs: d["opt_kwargs"] = opt_kwargs
@@ -339,8 +339,8 @@ def energy_firework(xyz,software,label,machine,software_kwargs={},parents=[],out
             node = MapTaskToNodes()
             newcommand = node.getCommand()
             software_kwargs["command"] = newcommand
-    else:
-        continue        
+        else:
+            continue        
     if software_kwargs: d["software_kwargs"] = software_kwargs
     d["ignore_errors"] = ignore_errors
     t1 = MolecularEnergyTask(d)
@@ -382,8 +382,8 @@ def vibrations_firework(xyz,software,label,machine,software_kwargs={},parents=[]
             node = MapTaskToNodes()
             newcommand = node.getCommand()
             software_kwargs["command"] = newcommand
-    else:
-        continue  
+        else:
+            continue  
     if software_kwargs: d["software_kwargs"] = software_kwargs
     if constraints: d["constraints"] = constraints
     d["ignore_errors"] = ignore_errors
@@ -754,8 +754,8 @@ def IRC_firework(xyz,label,out_path=None,spawn_jobs=False,software=None,machine=
                 node = MapTaskToNodes()
                 newcommand = node.getCommand()
                 software_kwargs["command"] = newcommand
-        else:
-            continue  
+            else:
+                continue  
         if out_path is None: out_path = os.path.join(directory,label+"_irc.traj")
         t1 = MolecularIRC(xyz=xyz,label=label,software=software,
             socket=socket,software_kwargs=software_kwargs,opt_kwargs=opt_kwargs,run_kwargs=run_kwargs,

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -60,8 +60,10 @@ def optimize_firework(xyz,software,label,machine,opt_method=None,sella=None,sock
                       run_kwargs={},constraints=[],parents=[],out_path=None,time_limit_hrs=np.inf,fmaxhard=0.0,ignore_errors=False,
                       target_site_num=None,metal=None,facet=None,priority=1,allow_fizzled_parents=False):
     d = {"xyz" : xyz, "software" : software,"label" : label}
+    print("machine",machine)
     if machine == "polaris":
         if software == "Espresso":
+            print("machine is polaris and using QE")
             node = MapTaskToNodes()
             newcommand = node.getCommand()
             software_kwargs["command"] = newcommand

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -374,13 +374,13 @@ class MolecularEnergyTask(EnergyTask):
         return FWAction()
 
 def vibrations_firework(xyz,software,label,machine,software_kwargs={},parents=[],out_path=None,constraints=[],socket=False,ignore_errors=False):
-    d = {"xyz" : xyz, "software" : software, "label" : label, "socket": socket, "machine": machine}
+    d = {"xyz" : xyz, "software" : software, "label" : label, "socket": socket}
     if machine == "polaris":
         if software == "Espresso":
             node = MapTaskToNodes()
             newcommand = node.getCommand()
             software_kwargs["command"] = newcommand
-
+            
     if software_kwargs: d["software_kwargs"] = software_kwargs
     if constraints: d["constraints"] = constraints
     d["ignore_errors"] = ignore_errors

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -61,12 +61,11 @@ def optimize_firework(xyz,software,label,machine,opt_method=None,sella=None,sock
                       target_site_num=None,metal=None,facet=None,priority=1,allow_fizzled_parents=False):
     d = {"xyz" : xyz, "software" : software,"label" : label, "machine": machine}
     if machine == "polaris":
-        for software == "Espresso":
+        if software == "Espresso":
             node = MapTaskToNodes()
             newcommand = node.getCommand()
             software_kwargs["command"] = newcommand
-        else:
-            continue
+
     if opt_method: d["opt_method"] = opt_method
     if software_kwargs: d["software_kwargs"] = software_kwargs
     if opt_kwargs: d["opt_kwargs"] = opt_kwargs
@@ -335,12 +334,11 @@ class MolecularOptimizationFailTask(OptimizationTask):
 def energy_firework(xyz,software,label,machine,software_kwargs={},parents=[],out_path=None,ignore_errors=False):
     d = {"xyz" : xyz, "software" : software, "label" : label, "machine": machine}
     if machine == "polaris":
-        for software == "Espresso":
+        if software == "Espresso":
             node = MapTaskToNodes()
             newcommand = node.getCommand()
             software_kwargs["command"] = newcommand
-        else:
-            continue        
+       
     if software_kwargs: d["software_kwargs"] = software_kwargs
     d["ignore_errors"] = ignore_errors
     t1 = MolecularEnergyTask(d)
@@ -378,12 +376,11 @@ class MolecularEnergyTask(EnergyTask):
 def vibrations_firework(xyz,software,label,machine,software_kwargs={},parents=[],out_path=None,constraints=[],socket=False,ignore_errors=False):
     d = {"xyz" : xyz, "software" : software, "label" : label, "socket": socket, "machine": machine}
     if machine == "polaris":
-        for software == "Espresso":
+        if software == "Espresso":
             node = MapTaskToNodes()
             newcommand = node.getCommand()
             software_kwargs["command"] = newcommand
-        else:
-            continue  
+
     if software_kwargs: d["software_kwargs"] = software_kwargs
     if constraints: d["constraints"] = constraints
     d["ignore_errors"] = ignore_errors
@@ -750,12 +747,11 @@ class MolecularTSNudge(FiretaskBase):
 def IRC_firework(xyz,label,out_path=None,spawn_jobs=False,software=None,machine=None,
         socket=False,software_kwargs={},opt_kwargs={},run_kwargs={},constraints=[],parents=[],ignore_errors=False,forward=True):
         if machine == "polaris":
-            for software == "Espresso":
+            if software == "Espresso":
                 node = MapTaskToNodes()
                 newcommand = node.getCommand()
                 software_kwargs["command"] = newcommand
-            else:
-                continue  
+
         if out_path is None: out_path = os.path.join(directory,label+"_irc.traj")
         t1 = MolecularIRC(xyz=xyz,label=label,software=software,
             socket=socket,software_kwargs=software_kwargs,opt_kwargs=opt_kwargs,run_kwargs=run_kwargs,

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -56,10 +56,17 @@ class DoNothingTask(FiretaskBase):
     def run_task(self, fw_spec):
         return FWAction()
 
-def optimize_firework(xyz,software,label,opt_method=None,sella=None,socket=False,order=0,software_kwargs={},opt_kwargs={},
+def optimize_firework(xyz,software,label,machine,opt_method=None,sella=None,socket=False,order=0,software_kwargs={},opt_kwargs={},
                       run_kwargs={},constraints=[],parents=[],out_path=None,time_limit_hrs=np.inf,fmaxhard=0.0,ignore_errors=False,
                       target_site_num=None,metal=None,facet=None,priority=1,allow_fizzled_parents=False):
-    d = {"xyz" : xyz, "software" : software,"label" : label}
+    d = {"xyz" : xyz, "software" : software,"label" : label, "machine": machine}
+    if machine == "polaris":
+        if software == "Espresso":
+            node = MapTaskToNodes()
+            newcommand = node.getCommand()
+            software_kwargs["command"] = newcommand
+    else:
+        continue   
     if opt_method: d["opt_method"] = opt_method
     if software_kwargs: d["software_kwargs"] = software_kwargs
     if opt_kwargs: d["opt_kwargs"] = opt_kwargs
@@ -325,8 +332,15 @@ class MolecularOptimizationFailTask(OptimizationTask):
 
         return FWAction()
 
-def energy_firework(xyz,software,label,software_kwargs={},parents=[],out_path=None,ignore_errors=False):
-    d = {"xyz" : xyz, "software" : software, "label" : label}
+def energy_firework(xyz,software,label,machine,software_kwargs={},parents=[],out_path=None,ignore_errors=False):
+    d = {"xyz" : xyz, "software" : software, "label" : label, "machine": machine}
+    if machine == "polaris":
+        if software == "Espresso":
+            node = MapTaskToNodes()
+            newcommand = node.getCommand()
+            software_kwargs["command"] = newcommand
+    else:
+        continue        
     if software_kwargs: d["software_kwargs"] = software_kwargs
     d["ignore_errors"] = ignore_errors
     t1 = MolecularEnergyTask(d)
@@ -361,8 +375,15 @@ class MolecularEnergyTask(EnergyTask):
 
         return FWAction()
 
-def vibrations_firework(xyz,software,label,software_kwargs={},parents=[],out_path=None,constraints=[],socket=False,ignore_errors=False):
-    d = {"xyz" : xyz, "software" : software, "label" : label, "socket": socket}
+def vibrations_firework(xyz,software,label,machine,software_kwargs={},parents=[],out_path=None,constraints=[],socket=False,ignore_errors=False):
+    d = {"xyz" : xyz, "software" : software, "label" : label, "socket": socket, "machine": machine}
+    if machine == "polaris":
+        if software == "Espresso":
+            node = MapTaskToNodes()
+            newcommand = node.getCommand()
+            software_kwargs["command"] = newcommand
+    else:
+        continue  
     if software_kwargs: d["software_kwargs"] = software_kwargs
     if constraints: d["constraints"] = constraints
     d["ignore_errors"] = ignore_errors
@@ -726,8 +747,15 @@ class MolecularTSNudge(FiretaskBase):
         else:
             return FWAction()
 
-def IRC_firework(xyz,label,out_path=None,spawn_jobs=False,software=None,
+def IRC_firework(xyz,label,out_path=None,spawn_jobs=False,software=None,machine=None,
         socket=False,software_kwargs={},opt_kwargs={},run_kwargs={},constraints=[],parents=[],ignore_errors=False,forward=True):
+        if machine == "polaris":
+            if software == "Espresso":
+                node = MapTaskToNodes()
+                newcommand = node.getCommand()
+                software_kwargs["command"] = newcommand
+        else:
+            continue  
         if out_path is None: out_path = os.path.join(directory,label+"_irc.traj")
         t1 = MolecularIRC(xyz=xyz,label=label,software=software,
             socket=socket,software_kwargs=software_kwargs,opt_kwargs=opt_kwargs,run_kwargs=run_kwargs,

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -380,7 +380,7 @@ def vibrations_firework(xyz,software,label,machine,software_kwargs={},parents=[]
             node = MapTaskToNodes()
             newcommand = node.getCommand()
             software_kwargs["command"] = newcommand
-            
+    if machine: d["machine"] = machine        
     if software_kwargs: d["software_kwargs"] = software_kwargs
     if constraints: d["constraints"] = constraints
     d["ignore_errors"] = ignore_errors

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -60,13 +60,13 @@ def optimize_firework(xyz,software,label,machine,opt_method=None,sella=None,sock
                       run_kwargs={},constraints=[],parents=[],out_path=None,time_limit_hrs=np.inf,fmaxhard=0.0,ignore_errors=False,
                       target_site_num=None,metal=None,facet=None,priority=1,allow_fizzled_parents=False):
     d = {"xyz" : xyz, "software" : software,"label" : label, "machine": machine}
-    if machine == "polaris":
+    for machine == "polaris":
         if software == "Espresso":
             node = MapTaskToNodes()
             newcommand = node.getCommand()
             software_kwargs["command"] = newcommand
     else:
-        continue   
+        continue
     if opt_method: d["opt_method"] = opt_method
     if software_kwargs: d["software_kwargs"] = software_kwargs
     if opt_kwargs: d["opt_kwargs"] = opt_kwargs
@@ -334,7 +334,7 @@ class MolecularOptimizationFailTask(OptimizationTask):
 
 def energy_firework(xyz,software,label,machine,software_kwargs={},parents=[],out_path=None,ignore_errors=False):
     d = {"xyz" : xyz, "software" : software, "label" : label, "machine": machine}
-    if machine == "polaris":
+    for machine == "polaris":
         if software == "Espresso":
             node = MapTaskToNodes()
             newcommand = node.getCommand()
@@ -377,7 +377,7 @@ class MolecularEnergyTask(EnergyTask):
 
 def vibrations_firework(xyz,software,label,machine,software_kwargs={},parents=[],out_path=None,constraints=[],socket=False,ignore_errors=False):
     d = {"xyz" : xyz, "software" : software, "label" : label, "socket": socket, "machine": machine}
-    if machine == "polaris":
+    for machine == "polaris":
         if software == "Espresso":
             node = MapTaskToNodes()
             newcommand = node.getCommand()
@@ -749,7 +749,7 @@ class MolecularTSNudge(FiretaskBase):
 
 def IRC_firework(xyz,label,out_path=None,spawn_jobs=False,software=None,machine=None,
         socket=False,software_kwargs={},opt_kwargs={},run_kwargs={},constraints=[],parents=[],ignore_errors=False,forward=True):
-        if machine == "polaris":
+        for machine == "polaris":
             if software == "Espresso":
                 node = MapTaskToNodes()
                 newcommand = node.getCommand()

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -61,7 +61,7 @@ def optimize_firework(xyz,software,label,machine,opt_method=None,sella=None,sock
                       target_site_num=None,metal=None,facet=None,priority=1,allow_fizzled_parents=False):
     d = {"xyz" : xyz, "software" : software,"label" : label, "machine": machine}
     if machine == "polaris":
-        if software == "Espresso":
+        for software == "Espresso":
             node = MapTaskToNodes()
             newcommand = node.getCommand()
             software_kwargs["command"] = newcommand
@@ -335,7 +335,7 @@ class MolecularOptimizationFailTask(OptimizationTask):
 def energy_firework(xyz,software,label,machine,software_kwargs={},parents=[],out_path=None,ignore_errors=False):
     d = {"xyz" : xyz, "software" : software, "label" : label, "machine": machine}
     if machine == "polaris":
-        if software == "Espresso":
+        for software == "Espresso":
             node = MapTaskToNodes()
             newcommand = node.getCommand()
             software_kwargs["command"] = newcommand
@@ -378,7 +378,7 @@ class MolecularEnergyTask(EnergyTask):
 def vibrations_firework(xyz,software,label,machine,software_kwargs={},parents=[],out_path=None,constraints=[],socket=False,ignore_errors=False):
     d = {"xyz" : xyz, "software" : software, "label" : label, "socket": socket, "machine": machine}
     if machine == "polaris":
-        if software == "Espresso":
+        for software == "Espresso":
             node = MapTaskToNodes()
             newcommand = node.getCommand()
             software_kwargs["command"] = newcommand
@@ -750,7 +750,7 @@ class MolecularTSNudge(FiretaskBase):
 def IRC_firework(xyz,label,out_path=None,spawn_jobs=False,software=None,machine=None,
         socket=False,software_kwargs={},opt_kwargs={},run_kwargs={},constraints=[],parents=[],ignore_errors=False,forward=True):
         if machine == "polaris":
-            if software == "Espresso":
+            for software == "Espresso":
                 node = MapTaskToNodes()
                 newcommand = node.getCommand()
                 software_kwargs["command"] = newcommand

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -60,7 +60,7 @@ def optimize_firework(xyz,software,label,machine,opt_method=None,sella=None,sock
                       run_kwargs={},constraints=[],parents=[],out_path=None,time_limit_hrs=np.inf,fmaxhard=0.0,ignore_errors=False,
                       target_site_num=None,metal=None,facet=None,priority=1,allow_fizzled_parents=False):
     d = {"xyz" : xyz, "software" : software,"label" : label, "machine": machine}
-    for machine == "polaris":
+    if machine == "polaris":
         if software == "Espresso":
             node = MapTaskToNodes()
             newcommand = node.getCommand()
@@ -334,7 +334,7 @@ class MolecularOptimizationFailTask(OptimizationTask):
 
 def energy_firework(xyz,software,label,machine,software_kwargs={},parents=[],out_path=None,ignore_errors=False):
     d = {"xyz" : xyz, "software" : software, "label" : label, "machine": machine}
-    for machine == "polaris":
+    if machine == "polaris":
         if software == "Espresso":
             node = MapTaskToNodes()
             newcommand = node.getCommand()
@@ -377,7 +377,7 @@ class MolecularEnergyTask(EnergyTask):
 
 def vibrations_firework(xyz,software,label,machine,software_kwargs={},parents=[],out_path=None,constraints=[],socket=False,ignore_errors=False):
     d = {"xyz" : xyz, "software" : software, "label" : label, "socket": socket, "machine": machine}
-    for machine == "polaris":
+    if machine == "polaris":
         if software == "Espresso":
             node = MapTaskToNodes()
             newcommand = node.getCommand()
@@ -749,7 +749,7 @@ class MolecularTSNudge(FiretaskBase):
 
 def IRC_firework(xyz,label,out_path=None,spawn_jobs=False,software=None,machine=None,
         socket=False,software_kwargs={},opt_kwargs={},run_kwargs={},constraints=[],parents=[],ignore_errors=False,forward=True):
-        for machine == "polaris":
+        if machine == "polaris":
             if software == "Espresso":
                 node = MapTaskToNodes()
                 newcommand = node.getCommand()

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -59,7 +59,7 @@ class DoNothingTask(FiretaskBase):
 def optimize_firework(xyz,software,label,machine,opt_method=None,sella=None,socket=False,order=0,software_kwargs={},opt_kwargs={},
                       run_kwargs={},constraints=[],parents=[],out_path=None,time_limit_hrs=np.inf,fmaxhard=0.0,ignore_errors=False,
                       target_site_num=None,metal=None,facet=None,priority=1,allow_fizzled_parents=False):
-    d = {"xyz" : xyz, "software" : software,"label" : label, "machine": machine}
+    d = {"xyz" : xyz, "software" : software,"label" : label}
     if machine == "polaris":
         if software == "Espresso":
             node = MapTaskToNodes()
@@ -332,7 +332,7 @@ class MolecularOptimizationFailTask(OptimizationTask):
         return FWAction()
 
 def energy_firework(xyz,software,label,machine,software_kwargs={},parents=[],out_path=None,ignore_errors=False):
-    d = {"xyz" : xyz, "software" : software, "label" : label, "machine": machine}
+    d = {"xyz" : xyz, "software" : software, "label" : label}
     if machine == "polaris":
         if software == "Espresso":
             node = MapTaskToNodes()
@@ -374,7 +374,7 @@ class MolecularEnergyTask(EnergyTask):
         return FWAction()
 
 def vibrations_firework(xyz,software,label,machine,software_kwargs={},parents=[],out_path=None,constraints=[],socket=False,ignore_errors=False):
-    d = {"xyz" : xyz, "software" : software, "label" : label, "socket": socket, "machine": machine}
+    d = {"xyz" : xyz, "software" : software, "label" : label, "socket": socket}
     if machine == "polaris":
         if software == "Espresso":
             node = MapTaskToNodes()

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -374,13 +374,13 @@ class MolecularEnergyTask(EnergyTask):
         return FWAction()
 
 def vibrations_firework(xyz,software,label,machine,software_kwargs={},parents=[],out_path=None,constraints=[],socket=False,ignore_errors=False):
-    d = {"xyz" : xyz, "software" : software, "label" : label, "socket": socket, "machine":machine}
+    d = {"xyz" : xyz, "software" : software, "label" : label, "socket": socket }
     if machine == "polaris":
         if software == "Espresso":
             node = MapTaskToNodes()
             newcommand = node.getCommand()
             software_kwargs["command"] = newcommand
-    if machine: d["machine"] = machine        
+            
     if software_kwargs: d["software_kwargs"] = software_kwargs
     if constraints: d["constraints"] = constraints
     d["ignore_errors"] = ignore_errors
@@ -685,7 +685,7 @@ class MolecularCollect(CollectTask):
                 d["out_path"] = os.path.join(os.path.split(xyz)[0],out_names[0][i])
                 d["label"] = out_names[0][i]
                 d["ignore_errors"] = True
-                d["machine"] = machine
+               
                 out_xyzs.append(d["out_path"])
                 fw = fw_generator(**d)
                 if not isinstance(fw,list):

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -374,7 +374,7 @@ class MolecularEnergyTask(EnergyTask):
         return FWAction()
 
 def vibrations_firework(xyz,software,label,machine,software_kwargs={},parents=[],out_path=None,constraints=[],socket=False,ignore_errors=False):
-    d = {"xyz" : xyz, "software" : software, "label" : label, "socket": socket}
+    d = {"xyz" : xyz, "software" : software, "label" : label, "socket": socket, "machine": machine}
     if machine == "polaris":
         if software == "Espresso":
             node = MapTaskToNodes()


### PR DESCRIPTION
## Describe your changes
1. Machine keyword is added to main.py and input script.
2. Polaris node mapping modules are added in utils.py. The module was originally designed by Raymundo H. from ALCF. When `machine:"polaris"` then optimization, energy and vibration fireworks jobs will use the polaris mapping scheme (task.py)

## Functionality
When `machine:"polaris"` in input script, then optimization, energy and vibration fireworks jobs will use the polaris mapping scheme (task.py). 

## Note
The keyword was tested in both Polaris, Perlmutter and Blodgett. It is confirmed that only when `machine:"polaris"`, it does follow the polaris mapping.
