### PR TITLE
Pynta restart fw 

### DIFF
--- a/pynta/calculator.py
+++ b/pynta/calculator.py
@@ -287,7 +287,7 @@ def run_harmonically_forced_xtb_no_pbc(atoms,atom_bond_potentials,site_bond_pote
     bigad.set_constraint(out_constraints)
     bigad.calc = hfxtb
 
-    opt = Sella(bigad,trajectory="xtbharm.traj",order=0)
+    opt = Sella(bigad,trajectory="xtbharm.traj",order=0,eta=1e-3)
 
     try:
         opt.run(fmax=0.02,steps=150)

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -504,6 +504,7 @@ class Pynta:
         """
         Call appropriate rapidfire function
         """
+<<<<<<< HEAD
         if self.queue:
             rapidfirequeue(self.launchpad,self.fworker,self.qadapter,njobs_queue=self.njobs_queue,nlaunches="infinite")
         elif not self.queue and (self.num_jobs == 1 or single_job):
@@ -511,6 +512,25 @@ class Pynta:
         else:
             listfworkers = createFWorkers(self.num_jobs)
             launch_multiprocess2(self.launchpad,listfworkers,"INFO",0,self.num_jobs,5)
+=======
+        if self.machine == "alcf":
+            print("You are using alcf machine: if you want to restart, run pyn.reset(wfid='1')")
+            if self.queue:
+                rapidfirequeue(self.launchpad,self.fworker,self.qadapter,njobs_queue=self.njobs_queue,nlaunches="infinite")
+            elif not self.queue and (self.num_jobs == 1 or single_job):
+                rapidfire(self.launchpad,self.fworker,nlaunches="infinite")
+            else:
+                listfworkers = createFWorkers(self.num_jobs)
+                launch_multiprocess2(self.launchpad,listfworkers,"INFO",0,self.num_jobs,5)
+        else:
+            print("machine choice is not alcf: check your Fireworks Workflow id before restart Pynta")
+            if self.queue:
+                rapidfirequeue(self.launchpad,self.fworker,self.qadapter,njobs_queue=self.njobs_queue,nlaunches="infinite")
+            elif not self.queue and (self.num_jobs == 1 or single_job):
+                rapidfire(self.launchpad,self.fworker,nlaunches="infinite")
+            else:
+                launch_multiprocess(self.launchpad,self.fworker,"INFO","infinite",self.num_jobs,5)
+>>>>>>> c8278d3 (modify reset() to add workflow id)
 
     def execute(self,generate_initial_ad_guesses=True,calculate_adsorbates=True,
                 calculate_transition_states=True,launch=True):
@@ -569,9 +589,11 @@ class Pynta:
         self.launch()
 
 #restart option: RHE
-    def reset(self):
+    def reset(self,wfid):
+
+        id_number = int(wfid)
         # Get the information of the workflow
-        wf1 = self.launchpad.get_wf_summary_dict(1, mode='more')
+        wf1 = self.launchpad.get_wf_summary_dict(id_number, mode='more')
 
         # Save the states of the workflow
         wf_states = wf1['states']

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -504,15 +504,6 @@ class Pynta:
         """
         Call appropriate rapidfire function
         """
-<<<<<<< HEAD
-        if self.queue:
-            rapidfirequeue(self.launchpad,self.fworker,self.qadapter,njobs_queue=self.njobs_queue,nlaunches="infinite")
-        elif not self.queue and (self.num_jobs == 1 or single_job):
-            rapidfire(self.launchpad,self.fworker,nlaunches="infinite")
-        else:
-            listfworkers = createFWorkers(self.num_jobs)
-            launch_multiprocess2(self.launchpad,listfworkers,"INFO",0,self.num_jobs,5)
-=======
         if self.machine == "alcf":
             print("You are using alcf machine: if you want to restart, run pyn.reset(wfid='1')")
             if self.queue:
@@ -530,7 +521,6 @@ class Pynta:
                 rapidfire(self.launchpad,self.fworker,nlaunches="infinite")
             else:
                 launch_multiprocess(self.launchpad,self.fworker,"INFO","infinite",self.num_jobs,5)
->>>>>>> c8278d3 (modify reset() to add workflow id)
 
     def execute(self,generate_initial_ad_guesses=True,calculate_adsorbates=True,
                 calculate_transition_states=True,launch=True):

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -32,6 +32,7 @@ import json
 class Pynta:
     def __init__(self,path,rxns_file,surface_type,metal,label,launchpad_path=None,fworker_path=None,
         vacuum=8.0,repeats=(3,3,4),slab_path=None,software="Espresso",socket=False,queue=False,njobs_queue=0,a=None,
+        machine=None,
         software_kwargs={'kpts': (3, 3, 1), 'tprnfor': True, 'occupations': 'smearing',
                             'smearing':  'marzari-vanderbilt',
                             'degauss': 0.01, 'ecutwfc': 40, 'nosym': True,
@@ -67,6 +68,7 @@ class Pynta:
         self.metal = metal
         self.adsorbate_fw_dict = dict()
         self.software_kwargs = software_kwargs
+        self.machine = machine #need to specify 'alcf' or other machine of choice
 
         if software_kwargs_gas:
             self.software_kwargs_gas = software_kwargs_gas
@@ -140,7 +142,7 @@ class Pynta:
         write(os.path.join(self.path,"slab_init.xyz"),slab)
         self.slab_path = os.path.join(self.path,"slab.xyz")
         if self.software != "XTB":
-            fwslab = optimize_firework(os.path.join(self.path,"slab_init.xyz"),self.software,"slab",
+            fwslab = optimize_firework(os.path.join(self.path,"slab_init.xyz"),self.software,self.machine,"slab",
                 opt_method="BFGSLineSearch",socket=self.socket,software_kwargs=self.software_kwargs,
                 run_kwargs={"fmax" : self.fmaxopt},out_path=os.path.join(self.path,"slab.xyz"),constraints=["freeze up to {}".format(self.freeze_ind)],priority=1000)
             wfslab = Workflow([fwslab], name=self.label+"_slab")
@@ -383,22 +385,22 @@ class Pynta:
                     xyz = os.path.join(self.path,"Adsorbates",adsname,str(prefix),str(prefix)+".xyz")
                     xyzs.append(xyz)
                     fwopt = optimize_firework(os.path.join(self.path,"Adsorbates",adsname,str(prefix),str(prefix)+"_init.xyz"),
-                        self.software,"weakopt_"+str(prefix),
+                        self.software,self.machine,"weakopt_"+str(prefix),
                         opt_method="MDMin",opt_kwargs={'dt': 0.05},socket=self.socket,software_kwargs=software_kwargs,
                         run_kwargs={"fmax" : 0.5, "steps" : 70},parents=[],constraints=constraints,
                         ignore_errors=True, metal=self.metal, facet=self.surface_type, target_site_num=target_site_num, priority=3)
                     fwopt2 = optimize_firework(os.path.join(self.path,"Adsorbates",adsname,str(prefix),"weakopt_"+str(prefix)+".xyz"),
-                        self.software,str(prefix),
+                        self.software,self.machine,str(prefix),
                         opt_method="QuasiNewton",socket=self.socket,software_kwargs=software_kwargs,
-                        run_kwargs={"fmax" : 0.5, "steps" : 70},parents=[fwopt],constraints=constraints,
-                        ignore_errors=True, metal=self.metal, facet=self.surface_type, target_site_num=target_site_num, priority=3, fmaxhard=0.1,
+                        run_kwargs={"fmax" : self.fmaxopt, "steps" : 70},parents=[fwopt],constraints=constraints,
+                        ignore_errors=True, metal=self.metal, facet=self.surface_type, target_site_num=target_site_num, priority=3, fmaxhard=self.fmaxopthard,
                         allow_fizzled_parents=True)
                     optfws.append(fwopt)
                     optfws.append(fwopt2)
                     optfws2.append(fwopt2)
 
                 vib_obj_dict = {"software": self.software, "label": adsname, "software_kwargs": software_kwargs,
-                    "constraints": ["freeze up to "+str(self.nslab)]}
+                    "machine": self.machine, "constraints": ["freeze up to "+str(self.nslab)]}
 
                 cfw = collect_firework(xyzs,True,["vibrations_firework"],[vib_obj_dict],["vib.json"],[],parents=optfws2,label=adsname)
                 self.adsorbate_fw_dict[adsname] = optfws2
@@ -443,21 +445,21 @@ class Pynta:
                     assert os.path.exists(init_path), init_path
                     xyzs.append(xyz)
                     fwopt = optimize_firework(init_path,
-                        self.software,"weakopt_"+str(prefix),
+                        self.software,self.machine,"weakopt_"+str(prefix),
                         opt_method="MDMin",opt_kwargs={'dt': 0.05},socket=self.socket,software_kwargs=software_kwargs,
                         run_kwargs={"fmax" : 0.5, "steps" : 70},parents=[],constraints=constraints,
                         ignore_errors=True, metal=self.metal, facet=self.surface_type, target_site_num=target_site_num, priority=3)
                     fwopt2 = optimize_firework(os.path.join(self.path,"Adsorbates",ad,str(prefix),"weakopt_"+str(prefix)+".xyz"),
-                        self.software,str(prefix),
+                        self.software,self.machine,str(prefix),
                         opt_method="QuasiNewton",socket=self.socket,software_kwargs=software_kwargs,
-                        run_kwargs={"fmax" : 0.1, "steps" : 70},parents=[fwopt],constraints=constraints,
+                        run_kwargs={"fmax" : self.fmaxopt, "steps" : 70},parents=[fwopt],constraints=constraints,
                         ignore_errors=True, metal=self.metal, facet=self.surface_type, target_site_num=target_site_num, priority=3)
                     optfws.append(fwopt)
                     optfws.append(fwopt2)
                     optfws2.append(fwopt2)
 
                 vib_obj_dict = {"software": self.software, "label": ad, "software_kwargs": software_kwargs,
-                    "constraints": ["freeze up to "+str(self.nslab)]}
+                    "machine": self.machine, "constraints": ["freeze up to "+str(self.nslab)]}
 
                 cfw = collect_firework(xyzs,True,["vibrations_firework"],[vib_obj_dict],["vib.json"],[True,False],parents=optfws2,label=ad,allow_fizzled_parents=False)
                 self.adsorbate_fw_dict[ad] = optfws2
@@ -471,26 +473,26 @@ class Pynta:
         Note the vibrational and IRC calculations are launched at the same time
         """
         if self.software != "XTB":
-            opt_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs_TS,
+            opt_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs_TS,"machine": self.machine,
                 "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)],"sella":True,"order":1,}
         else:
-            opt_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs_TS,
+            opt_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs_TS,"machine": self.machine,
                 "run_kwargs": {"fmax" : 0.02, "steps" : 70},"constraints": ["freeze up to "+str(self.nslab)],"sella":True,"order":1,}
         vib_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
-                "constraints": ["freeze up to "+str(self.nslab)]}
+                "machine": self.machine, "constraints": ["freeze up to "+str(self.nslab)]}
         IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
-                "run_kwargs": {"fmax" : self.fmaxirc, "steps" : 70},"constraints":["freeze up to "+str(self.nslab)]}
+                "machine": self.machine, "run_kwargs": {"fmax" : self.fmaxirc, "steps" : 70},"constraints":["freeze up to "+str(self.nslab)]}
         for i,rxn in enumerate(self.rxns_dict):
             ts_path = os.path.join(self.path,"TS"+str(i))
             os.makedirs(ts_path)
             ts_task = MolecularTSEstimate({"rxn": rxn,"ts_path": ts_path,"slab_path": self.slab_path,"adsorbates_path": os.path.join(self.path,"Adsorbates"),
-                "rxns_file": self.rxns_file,"path": self.path,"metal": self.metal,"facet": self.surface_type, "out_path": ts_path,
+                "rxns_file": self.rxns_file,"path": self.path,"metal": self.metal,"facet": self.surface_type, "out_path": ts_path, "machine": self.machine,
                 "spawn_jobs": True, "opt_obj_dict": opt_obj_dict, "vib_obj_dict": vib_obj_dict,
                     "IRC_obj_dict": IRC_obj_dict, "nprocs": 48, "name_to_adjlist_dict": self.name_to_adjlist_dict,
                     "gratom_to_molecule_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_atom_maps.items()},
                     "gratom_to_molecule_surface_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_surface_atom_maps.items()},
                     "nslab":self.nslab,"Eharmtol":self.Eharmtol,"Eharmfiltertol":self.Eharmfiltertol,"Ntsmin":self.Ntsmin,
-                    "max_num_hfsp_opts":self.max_num_hfsp_opts})
+                    "max_num_hfsp_opts":self.max_num_hfsp_opts, "acat_tol": self.acat_tol, "emt_metal": self.emt_metal})
             reactants = rxn["reactant_names"]
             products = rxn["product_names"]
             parents = []

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -42,7 +42,7 @@ class Pynta:
         TS_opt_software_kwargs=None,
         lattice_opt_software_kwargs={'kpts': (25,25,25), 'ecutwfc': 70, 'degauss':0.02, 'mixing_mode': 'plain'},
         reset_launchpad=False,queue_adapter_path=None,num_jobs=25,max_num_hfsp_opts=None,#max_num_hfsp_opts is mostly for fast testing
-        Eharmtol=3.0,Eharmfiltertol=30.0,Ntsmin=5,frozen_layers=2,fmaxopt=0.1,fmaxirc=0.1,fmaxopthard=0.1,pickled=0):
+        Eharmtol=3.0,Eharmfiltertol=30.0,Ntsmin=5,frozen_layers=2,fmaxopt=0.05,fmaxirc=0.1,fmaxopthard=0.05,pickled=0):
 
         self.surface_type = surface_type
         self.pickled = pickled

--- a/pynta/polaris.py
+++ b/pynta/polaris.py
@@ -8,7 +8,7 @@ from fireworks.core.fworker import FWorker
 def createCommand(node, software):
     binary = os.environ.get("EXE")
     if binary is None:
-        binary = '/lus/eagle/projects/catalysis_aesp/abagusetty/qe-7.1/build_cuda_nompiaware/bin/pw.x'
+        binary = '/lus/eagle/projects/catalysis_aesp/raymundohe/soft/qe-7.1/build_cuda_nogpuawarempi_openmp/bin/pw.x'
 
     if software == 'Espresso':
         command = 'mpiexec --hosts {} -n 4 --ppn 4 --depth=8 --cpu-bind depth --env OMP_NUM_THREADS=8 --env CUDA_VISIBLE_DEVICES=0,1,2,3 {} -in PREFIX.pwi > PREFIX.pwo'.format(node, binary)
@@ -35,6 +35,7 @@ def createFWorkers(num_jobs):
 
     for i in range(num_jobs):
         host = nodes_list[i]
+        print("host", host)
         env = {'host': host}
 
         fworkers.append(FWorker(env=env))

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -59,11 +59,7 @@ class DoNothingTask(FiretaskBase):
         return FWAction()
 
 def optimize_firework(xyz,software,machine,label,opt_method=None,sella=None,socket=False,order=0,software_kwargs={},opt_kwargs={},
-<<<<<<< HEAD
                       run_kwargs={},constraints=[],parents=[],out_path=None,time_limit_hrs=np.inf,fmaxhard=0.0,ignore_errors=False,
-=======
-                      run_kwargs={},constraints=[],parents=[],out_path=None,time_limit_hrs=np.inf,fmaxhard=0.10,ignore_errors=False,
->>>>>>> 83f979f (fmax value hardcoded to 0.1 (temporarily))
                       target_site_num=None,metal=None,facet=None,priority=1,allow_fizzled_parents=False):
     d = {"xyz" : xyz, "software" : software,"label" : label, "machine":machine}
     if opt_method: d["opt_method"] = opt_method

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -523,11 +523,6 @@ class MolecularTSEstimate(FiretaskBase):
         cas = SlabAdsorptionSites(slab,facet,allow_6fold=False,composition_effect=False,
                             label_sites=True,tol=acat_tol,
                         surrogate_metal=emt_metal)
-<<<<<<< HEAD
-
-=======
-#
->>>>>>> 83f979f (fmax value hardcoded to 0.1 (temporarily))
         adsorbates_path = self["adsorbates_path"]
 
 

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -59,7 +59,11 @@ class DoNothingTask(FiretaskBase):
         return FWAction()
 
 def optimize_firework(xyz,software,machine,label,opt_method=None,sella=None,socket=False,order=0,software_kwargs={},opt_kwargs={},
+<<<<<<< HEAD
                       run_kwargs={},constraints=[],parents=[],out_path=None,time_limit_hrs=np.inf,fmaxhard=0.0,ignore_errors=False,
+=======
+                      run_kwargs={},constraints=[],parents=[],out_path=None,time_limit_hrs=np.inf,fmaxhard=0.10,ignore_errors=False,
+>>>>>>> 83f979f (fmax value hardcoded to 0.1 (temporarily))
                       target_site_num=None,metal=None,facet=None,priority=1,allow_fizzled_parents=False):
     d = {"xyz" : xyz, "software" : software,"label" : label, "machine":machine}
     if opt_method: d["opt_method"] = opt_method
@@ -217,7 +221,7 @@ class MolecularOptimizationTask(OptimizationTask):
 
             sp.set_constraint(out_constraints)
 
-            opt = Sella(sp,trajectory=label+".traj",order=order)
+            opt = Sella(sp,trajectory=label+".traj",order=order,eta=1e-3)
             try:
                 if np.isinf(time_limit_hrs):
                     opt.run(**run_kwargs)
@@ -247,6 +251,8 @@ class MolecularOptimizationTask(OptimizationTask):
             fmax = np.inf
             try:
                 fmax = get_fmax(sp)
+                print("fmax",fmax)
+                print("fmaxhard",fmaxhard)
             except:
                 pass
             try:
@@ -324,7 +330,7 @@ class MolecularOptimizationFailTask(OptimizationTask):
 
         sp.calc = software
         opt = opt_method(sp,trajectory=label+".traj")
-        opt.run(fmax=0.02,steps=2)
+        opt.run(fmax=0.50,steps=2)
 
         if not opt.converged():
             fw = restart_opt_firework(self,fw_spec["_tasks"])
@@ -521,7 +527,11 @@ class MolecularTSEstimate(FiretaskBase):
         cas = SlabAdsorptionSites(slab,facet,allow_6fold=False,composition_effect=False,
                             label_sites=True,tol=acat_tol,
                         surrogate_metal=emt_metal)
+<<<<<<< HEAD
 
+=======
+#
+>>>>>>> 83f979f (fmax value hardcoded to 0.1 (temporarily))
         adsorbates_path = self["adsorbates_path"]
 
 
@@ -543,7 +553,7 @@ class MolecularTSEstimate(FiretaskBase):
         product_mols = [mol_dict[name] for name in product_names]
 
         adsorbates = get_unique_optimized_adsorbates(rxn,adsorbates_path,mol_dict,cas,gratom_to_molecule_surface_atom_maps,nslab)
-
+        print("adsorbate_path",adsorbates_path)
         forward,species_names = determine_TS_construction(reactant_names,
                     reactant_mols,product_names,product_mols)
 

--- a/pynta/utils.py
+++ b/pynta/utils.py
@@ -26,18 +26,20 @@ def get_unique_sym(geoms):
     '''
     comparator = SymmetryEquivalenceCheck()
 
+    geoms_copy = deepcopy(geoms)
     good_adsorbates_atom_obj_list = []
     geos_out = []
 
-    for geom in geoms:
+    for i, geom in enumerate(geoms_copy):
         adsorbate_atom_obj = read(geom)
         adsorbate_atom_obj.pbc = True
+        adsorbate_atom_obj.set_constraint()  # Reset constraints
         comparision = comparator.compare(
             adsorbate_atom_obj, good_adsorbates_atom_obj_list)
 
         if comparision is False:
             good_adsorbates_atom_obj_list.append(adsorbate_atom_obj)
-            geos_out.append(geom)
+            geos_out.append(geom[i])
 
     return geos_out
 
@@ -51,18 +53,20 @@ def get_unique_sym_indices(geoms):
     '''
     comparator = SymmetryEquivalenceCheck()
 
+    geoms_copy = deepcopy(geoms)
     good_adsorbates_atom_obj_list = []
     geos_out = []
 
-    for geom in geoms:
+    for i, geom in enumerate(geoms_copy):
         adsorbate_atom_obj = read(geom)
         adsorbate_atom_obj.pbc = True
+        adsorbate_atom_obj.set_constraint()  
         comparision = comparator.compare(
             adsorbate_atom_obj, good_adsorbates_atom_obj_list)
 
         if comparision is False:
             good_adsorbates_atom_obj_list.append(adsorbate_atom_obj)
-            geos_out.append(geom)
+            geos_out.append(geoms[i])
 
     indices = [geoms.index(g) for g in geos_out]
 
@@ -87,6 +91,7 @@ def get_unique_sym_structs(geoms):
     for i,geom in enumerate(geoms_copy):
         adsorbate_atom_obj = geom
         adsorbate_atom_obj.pbc = True
+        adsorbate_atom_obj.set_constraint()  # Reset constraints
         comparision = comparator.compare(
             adsorbate_atom_obj, good_adsorbates_atom_obj_list)
 
@@ -115,6 +120,7 @@ def get_unique_sym_struct_indices(geoms):
     for i,geom in enumerate(geoms_copy):
         adsorbate_atom_obj = geom
         adsorbate_atom_obj.pbc = True
+        adsorbate_atom_obj.set_constraint()  # Reset constraints
         comparision = comparator.compare(
             adsorbate_atom_obj, good_adsorbates_atom_obj_list)
 
@@ -143,6 +149,7 @@ def get_unique_sym_struct_index_clusters(geoms):
     for i,geom in enumerate(geoms_copy):
         adsorbate_atom_obj = geom
         adsorbate_atom_obj.pbc = True
+        adsorbate_atom_obj.set_constraint()  # Reset constraints
         comparison = None
         for j,adlist in enumerate(good_adsorbates_atom_obj_list):
             comparison = comparator.compare(adsorbate_atom_obj, [adlist[0]])
@@ -168,19 +175,22 @@ def filter_nonunique_TS_guess_indices(geoms,Es):
     geoms: list of paths to .xyz or .traj files to compare
 
     '''
+
+    geoms_copy = deepcopy(geoms)
     comparator = SymmetryEquivalenceCheck()
 
     good_adsorbates_atom_obj_list = []
     geos_out = []
     Esout = []
 
-    for j,geom in enumerate(geoms):
+    for j,geom in enumerate(geoms_copy):
         adsorbate_atom_obj = read(geom)
         adsorbate_atom_obj.pbc = True
+        adsorbate_atom_obj.set_constraint()  # Reset constraints
         for i,good_adsorbate in enumerate(good_adsorbates_atom_obj_list):
             comparison = comparator.compare(adsorbate_atom_obj,good_adsorbate)
             if comparison and Es[j] < Esout[i]:
-                geos_out[i] = geom
+                geos_out[i] = geoms[j]
                 good_adsorbates_atom_obj_list[i] = adsorbate_atom_obj
                 Esout[i] = Es[j]
                 break
@@ -188,7 +198,7 @@ def filter_nonunique_TS_guess_indices(geoms,Es):
                 break
         else:
             good_adsorbates_atom_obj_list.append(adsorbate_atom_obj)
-            geos_out.append(geom)
+            geos_out.append(geoms[j])
             Esout.append(Es[j])
 
     return geos_out,Esout
@@ -206,6 +216,9 @@ def name_to_ase_software(software_name):
         return getattr(module, software_name)
     elif software_name == "PWDFT":
         module = import_module("pynta.ase_pwdft.pwdft")
+        return getattr(module, software_name)
+    elif software_name == 'DP':
+        module = import_module('deepmd.calculator')
         return getattr(module, software_name)
     else:
         module = import_module("ase.calculators."+software_name.lower())


### PR DESCRIPTION
**Previous comment from Ray (October 2023):**
I have updated the way we map tasks on each node for ALCF machines. Each task runs on a different FWorker, and each FWorker is associated with a node. This is available for multilauncher. The optimal approach is to set num_jobs to the number of nodes.

Additionally, I have added functionality to use PWDFT, including the calculator and related functions.


------------------------------------------------------------------------------------------------------------------

**Updated comments from Shinae (Feb 2024)**
I have updated the way we restart Pynta based on how Ray implemented the restart from Polaris.
From Pynta object, `machine=<Machine type> `should be specified to restart Pynta. Also for NERSC and any other machines, workflow id should be added to **pyn.reset()** to rerun the previous workflow. 
pyn.reset() is tested in Perlmutter and was able to restart from `queue=True` mode. 

This updates include Trevor's pull request (https://github.com/zadorlab/pynta/pull/33), which not yet merged. 