### PR TITLE
Fix CI tests

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,3 +23,4 @@ dependencies:
   - libffi <=3.3
   - nose
   - coverage
+  - liblapack !=3.9.0


### PR DESCRIPTION
Avoid use of liblapack 21_openblas build. This build on osx64 and linux64 causes this below error in Sella during the HFSP optimizations: 
```
Traceback (most recent call last):
  File "/Users/mjohns9/mambaforge/envs/pynta_env/lib/python3.8/site-packages/fireworks/core/rocket.py", line 261, in run
    m_action = t.run_task(my_spec)
  File "/Users/mjohns9/code/pynta/pynta/tasks.py", line 598, in run_task
    outputs = list(map(map_harmonically_forced_xtb,inputs))
  File "/Users/mjohns9/code/pynta/pynta/tasks.py", line 909, in map_harmonically_forced_xtb
    sp,Eharm,Fharm = run_harmonically_forced_xtb(tsstruct,atom_bond_potentials,site_bond_potentials,nslab,
  File "/Users/mjohns9/code/pynta/pynta/calculator.py", line 135, in run_harmonically_forced_xtb
    opt.run(fmax=0.02,steps=150)
  File "/Users/mjohns9/mambaforge/envs/pynta_env/lib/python3.8/site-packages/ase/optimize/optimize.py", line 269, in run
    return Dynamics.run(self)
  File "/Users/mjohns9/mambaforge/envs/pynta_env/lib/python3.8/site-packages/ase/optimize/optimize.py", line 156, in run
    for converged in Dynamics.irun(self):
  File "/Users/mjohns9/mambaforge/envs/pynta_env/lib/python3.8/site-packages/ase/optimize/optimize.py", line 135, in irun
    self.step()
  File "/Users/mjohns9/mambaforge/envs/pynta_env/lib/python3.8/site-packages/sella/optimize/optimize.py", line 235, in step
    rho = self.pes.kick(s, ev, **self.diagkwargs)
  File "/Users/mjohns9/mambaforge/envs/pynta_env/lib/python3.8/site-packages/sella/peswrapper.py", line 327, in kick
    self._update_H(dx_final, dg_actual)
  File "/Users/mjohns9/mambaforge/envs/pynta_env/lib/python3.8/site-packages/sella/peswrapper.py", line 220, in _update_H
    self.H.update(dx, dg)
  File "/Users/mjohns9/mambaforge/envs/pynta_env/lib/python3.8/site-packages/sella/linalg.py", line 179, in update
    B[:self.ncart, :self.ncart] = update_H(
  File "/Users/mjohns9/mambaforge/envs/pynta_env/lib/python3.8/site-packages/sella/hessian_update.py", line 51, in update_H
    thetas, _ = eigh(S.T @ Ytilde)
  File "/Users/mjohns9/mambaforge/envs/pynta_env/lib/python3.8/site-packages/scipy/linalg/_decomp.py", line 561, in eigh
    w, v, *other_args, info = drv(a=a1, **drv_args, **lwork_args)
_flapack.error: (liwork>=max(1,10*n)||liwork==-1) failed for 10th keyword liwork: dsyevr:liwork=1
```