### PR TITLE
Pynta calculate IRC in different mode by user's choice

### DIFF
--- a/pynta/main.py
+++ b/pynta/main.py
@@ -470,45 +470,11 @@ class Pynta:
                 IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
                     "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to "+str(self.nslab)]}
 
-                ts_task = MolecularTSEstimate({"rxn": rxn,"ts_path": ts_path,"slab_path": self.slab_path,"adsorbates_path": os.path.join(self.path,"Adsorbates"),
-                            "rxns_file": self.rxns_file,"path": self.path,"metal": self.metal,"facet": self.surface_type, "out_path": ts_path,
-                            "spawn_jobs": True, "opt_obj_dict": opt_obj_dict, "vib_obj_dict": vib_obj_dict,
-                            "IRC_obj_dict": IRC_obj_dict, "nprocs": 48, "name_to_adjlist_dict": self.name_to_adjlist_dict,
-                            "gratom_to_molecule_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_atom_maps.items()},
-                            "gratom_to_molecule_surface_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_surface_atom_maps.items()},
-                            "nslab":self.nslab,"Eharmtol":self.Eharmtol,"Eharmfiltertol":self.Eharmfiltertol,"Ntsmin":self.Ntsmin,
-                            "max_num_hfsp_opts":self.max_num_hfsp_opts})
-                reactants = rxn["reactant_names"]
-                products = rxn["product_names"]
-                parents = []
-                if not adsorbates_finished:
-                    for m in reactants+products:
-                        parents.extend(self.adsorbate_fw_dict[m])
-                fw = Firework([ts_task],parents=parents,name="TS"+str(i)+"est",spec={"_allow_fizzled_parents": True,"_priority": 10})
-                self.fws.append(fw)
-
             elif self.irc_mode == "relaxed":
                 print("Top half of the slab is relaxed")
                 print(f"======================================================================")
                 IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
                 "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)]}
-
-                ts_task = MolecularTSEstimate({"rxn": rxn,"ts_path": ts_path,"slab_path": self.slab_path,"adsorbates_path": os.path.join(self.path,"Adsorbates"),
-                            "rxns_file": self.rxns_file,"path": self.path,"metal": self.metal,"facet": self.surface_type, "out_path": ts_path,
-                            "spawn_jobs": True, "opt_obj_dict": opt_obj_dict, "vib_obj_dict": vib_obj_dict,
-                            "IRC_obj_dict": IRC_obj_dict, "nprocs": 48, "name_to_adjlist_dict": self.name_to_adjlist_dict,
-                            "gratom_to_molecule_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_atom_maps.items()},
-                            "gratom_to_molecule_surface_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_surface_atom_maps.items()},
-                            "nslab":self.nslab,"Eharmtol":self.Eharmtol,"Eharmfiltertol":self.Eharmfiltertol,"Ntsmin":self.Ntsmin,
-                            "max_num_hfsp_opts":self.max_num_hfsp_opts})
-                reactants = rxn["reactant_names"]
-                products = rxn["product_names"]
-                parents = []
-                if not adsorbates_finished:
-                    for m in reactants+products:
-                        parents.extend(self.adsorbate_fw_dict[m])
-                fw = Firework([ts_task],parents=parents,name="TS"+str(i)+"est",spec={"_allow_fizzled_parents": True,"_priority": 10})
-                self.fws.append(fw)
         # if irc_mode = "skip" : do not conduct IRC
             else:
                 print("Skip IRC: IRC is not conducted")

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -473,11 +473,11 @@ class Pynta:
             #if irc_mode is "fixed" freeze all slab and conduct MolecularTSEstimate. 
             if self.irc_mode == "fixed":
                 IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
-                    "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to "+str(self.nslab)], "irc_mode":self.irc_mode}
+                    "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to "+str(self.nslab)]}
 
             elif self.irc_mode == "relaxed":
                 IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
-                "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)],"irc_mode":self.irc_mode}
+                    "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)]}
         # if irc_mode = "skip" : do not conduct IRC
             else:
                 logger.info("Skip IRC: IRC is not conducted")

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -485,15 +485,16 @@ class Pynta:
                     "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)]}
         # if irc_mode = "skip" : do not conduct IRC
             else:
-                self.irc_mode = "skip"
                 print("==Skip IRC: IRC is not conducted==")
                 logger.info("==Skip IRC: IRC is not conducted==")
+                IRC_obj_dict = {}
+                pass
 
             ts_path = os.path.join(self.path,"TS"+str(i))
             os.makedirs(ts_path)
             ts_task = MolecularTSEstimate({"rxn": rxn,"ts_path": ts_path,"slab_path": self.slab_path,"adsorbates_path": os.path.join(self.path,"Adsorbates"),
                     "rxns_file": self.rxns_file,"path": self.path,"metal": self.metal,"facet": self.surface_type, "out_path": ts_path, "irc_mode": self.irc_mode,
-                    "spawn_jobs": True, "opt_obj_dict": opt_obj_dict, "vib_obj_dict": vib_obj_dict,
+                    "spawn_jobs": True, "opt_obj_dict": opt_obj_dict, "vib_obj_dict": vib_obj_dict, "IRC_obj_dict": IRC_obj_dict,
                     "nprocs": 48, "name_to_adjlist_dict": self.name_to_adjlist_dict,
                     "gratom_to_molecule_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_atom_maps.items()},
                     "gratom_to_molecule_surface_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_surface_atom_maps.items()},

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -502,7 +502,7 @@ class Pynta:
         # if irc_mode = "skip" : do not conduct IRC
             else:
                 print("Skip IRC: IRC is not conducted") 
-                ts_task = MolecularTSEstimate({"rxn": rxn,"ts_path": ts_path,"slab_path": self.slab_path,"adsorbates_path": os.path.join(self.path,"Adsorbates"),
+                ts_task = MolecularTSEstimate_noIRC({"rxn": rxn,"ts_path": ts_path,"slab_path": self.slab_path,"adsorbates_path": os.path.join(self.path,"Adsorbates"),
                             "rxns_file": self.rxns_file,"path": self.path,"metal": self.metal,"facet": self.surface_type, "out_path": ts_path,
                             "spawn_jobs": True, "opt_obj_dict": opt_obj_dict, "vib_obj_dict": vib_obj_dict,
                             "nprocs": 48, "name_to_adjlist_dict": self.name_to_adjlist_dict,

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -456,12 +456,13 @@ class Pynta:
             IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
                 "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)]}
         # if irc_mode = "relaxed" : freeze half of the slab
-        if self.irc_mode == "relaxed":
+        elif self.irc_mode == "relaxed":
             IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
                 "run_kwargs": {"fmax" : self.fmaxirc, "steps" : 70},"constraints":["freeze up to "+str(self.nslab)]}
         # if irc_mode = "skip" : do not conduct IRC
-        if self.irc_mode == "skip":
+        else:
             print("Skip IRC: IRC is not conducted")
+            pass
          
         print(f"irc_mode is: {self.irc_mode}, IRC_obj_dict: {IRC_obj_dict}")
 

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -442,6 +442,10 @@ class Pynta:
         Sets up fireworks to generate and filter a set of TS estimates, optimize each unique TS estimate,
         and run vibrational and IRC calculations on the each unique final transition state
         Note the vibrational and IRC calculations are launched at the same time
+
+        If irc_mode is "fixed", entire slab layers are fixed. 
+        If irc_mode is "relaxed", bottom half of slab layers are fixed and top half of slab layers are relaxed.
+        If irc_mode is not "fixed" nor "relaxed", IRC is not calculated
         """
         if self.software != "XTB":
             opt_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs_TS,
@@ -452,7 +456,7 @@ class Pynta:
         vib_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
                 "constraints": ["freeze up to "+str(self.nslab)]}
 
-        print(f"irc_mode is: {self.irc_mode}")
+        print(f"================= IRC mode is: {self.irc_mode} =======================")
 
         for i,rxn in enumerate(self.rxns_dict):
             ts_path = os.path.join(self.path,"TS"+str(i))
@@ -518,8 +522,6 @@ class Pynta:
                         parents.extend(self.adsorbate_fw_dict[m])
                 fw = Firework([ts_task],parents=parents,name="TS"+str(i)+"est",spec={"_allow_fizzled_parents": True,"_priority": 10})
                 self.fws.append(fw)
-
-        print(f"irc_mode is: {self.irc_mode}")
 
     def launch(self,single_job=False):
         """

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -473,11 +473,11 @@ class Pynta:
             #if irc_mode is "fixed" freeze all slab and conduct MolecularTSEstimate. 
             if self.irc_mode == "fixed":
                 IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
-                    "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to "+str(self.nslab)]}
+                    "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to "+str(self.nslab)], "irc_mode":self.irc_mode}
 
             elif self.irc_mode == "relaxed":
                 IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
-                    "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)]}
+                "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)],"irc_mode":self.irc_mode}
         # if irc_mode = "skip" : do not conduct IRC
             else:
                 logger.info("Skip IRC: IRC is not conducted")

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -471,31 +471,30 @@ class Pynta:
         #pass through 
         
         for i,rxn in enumerate(self.rxns_dict):
-            ts_path = os.path.join(self.path,"TS"+str(i))
-            os.makedirs(ts_path)
             #if irc_mode is "fixed" freeze all slab and conduct MolecularTSEstimate. 
             if self.irc_mode == "fixed":
                 print("==Entire slab layers are frozen==")
                 logging.info("Entire slab layers are frozen")
                 IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
-                    "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to "+str(self.nslab)], "irc_mode":self.irc_mode}
+                    "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to "+str(self.nslab)]}
 
             elif self.irc_mode == "relaxed":
                 print("==Top half of the slab is relaxed==")
                 logger.info("==Top half of the slab is relaxed==")
                 IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
-                "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)],"irc_mode":self.irc_mode}
+                    "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)]}
         # if irc_mode = "skip" : do not conduct IRC
             else:
                 print("==Skip IRC: IRC is not conducted==")
                 logger.info("==Skip IRC: IRC is not conducted==")
-                pass
+                IRC_obj_dict = {}
+
             ts_path = os.path.join(self.path,"TS"+str(i))
             os.makedirs(ts_path)
             ts_task = MolecularTSEstimate({"rxn": rxn,"ts_path": ts_path,"slab_path": self.slab_path,"adsorbates_path": os.path.join(self.path,"Adsorbates"),
-                "rxns_file": self.rxns_file,"path": self.path,"metal": self.metal,"facet": self.surface_type, "out_path": ts_path, "irc_mode": self.irc_mode,
-                "spawn_jobs": True, "opt_obj_dict": opt_obj_dict, "vib_obj_dict": vib_obj_dict,
-                    "IRC_obj_dict": IRC_obj_dict, "nprocs": 48, "name_to_adjlist_dict": self.name_to_adjlist_dict,
+                    "rxns_file": self.rxns_file,"path": self.path,"metal": self.metal,"facet": self.surface_type, "out_path": ts_path, "irc_mode": self.irc_mode,
+                    "spawn_jobs": True, "opt_obj_dict": opt_obj_dict, "vib_obj_dict": vib_obj_dict, "IRC_obj_dict": IRC_obj_dict,
+                    "nprocs": 48, "name_to_adjlist_dict": self.name_to_adjlist_dict,
                     "gratom_to_molecule_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_atom_maps.items()},
                     "gratom_to_molecule_surface_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_surface_atom_maps.items()},
                     "nslab":self.nslab,"Eharmtol":self.Eharmtol,"Eharmfiltertol":self.Eharmfiltertol,"Ntsmin":self.Ntsmin,
@@ -503,6 +502,7 @@ class Pynta:
             reactants = rxn["reactant_names"]
             products = rxn["product_names"]
             parents = []
+            
             if not adsorbates_finished:
                 for m in reactants+products:
                     parents.extend(self.adsorbate_fw_dict[m])

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -487,7 +487,6 @@ class Pynta:
             else:
                 print("==Skip IRC: IRC is not conducted==")
                 logger.info("==Skip IRC: IRC is not conducted==")
-                IRC_obj_dict = {}
 
             ts_path = os.path.join(self.path,"TS"+str(i))
             os.makedirs(ts_path)
@@ -502,7 +501,6 @@ class Pynta:
             reactants = rxn["reactant_names"]
             products = rxn["product_names"]
             parents = []
-            
             if not adsorbates_finished:
                 for m in reactants+products:
                     parents.extend(self.adsorbate_fw_dict[m])

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -22,6 +22,11 @@ from fireworks.core.fworker import FWorker
 import fireworks.fw_config
 import logging
 
+#logger
+logger = logging.getLogger(__name__)
+logging.basicConfig(filename='pynta.log', encoding='utf-8', level=logging.INFO)
+
+
 class Pynta:
     def __init__(self,path,rxns_file,surface_type,metal,label,launchpad_path=None,fworker_path=None,
         vacuum=8.0,repeats=(3,3,4),slab_path=None,software="Espresso", pbc=(True,True,False),socket=False,queue=False,njobs_queue=0,a=None,
@@ -118,6 +123,8 @@ class Pynta:
         self.fmaxirc = fmaxirc
         self.fmaxopthard = fmaxopthard
 
+        logger.info('Pynta class is initiated')
+
     def generate_slab(self,skip_launch=False):
         """
         generates and optimizes a small scale slab that can be scaled to a large slab as needed
@@ -131,6 +138,7 @@ class Pynta:
             self.a = a
         else:
             a = self.a
+        logger.info('Construct slab with optimal lattice constant')
         #construct slab with optimial lattice constant
         slab = slab_type(self.metal,self.repeats,a,self.vacuum)
         slab.pbc = self.pbc
@@ -458,7 +466,7 @@ class Pynta:
                 "constraints": ["freeze up to "+str(self.nslab)]}
 
         #logging.info
-        print(f"================= IRC mode is: {self.irc_mode} =======================")
+        logger.info(f"================= IRC mode is: {self.irc_mode} =======================")
         #pass through 
         
         for i,rxn in enumerate(self.rxns_dict):
@@ -466,21 +474,17 @@ class Pynta:
             os.makedirs(ts_path)
             #if irc_mode is "fixed" freeze all slab and conduct MolecularTSEstimate. 
             if self.irc_mode == "fixed":
-                print("Entire slab layers are frozen")
-                print(f"======================================================================")
-
+                logging.info("Entire slab layers are frozen")
                 IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
                     "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to "+str(self.nslab)]}
 
             elif self.irc_mode == "relaxed":
-                print("Top half of the slab is relaxed")
-                print(f"======================================================================")
+                logger.info("Top half of the slab is relaxed")
                 IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
                 "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)]}
         # if irc_mode = "skip" : do not conduct IRC
             else:
-                print("Skip IRC: IRC is not conducted")
-                print(f"======================================================================")
+                logger.info("Skip IRC: IRC is not conducted")
                 pass
 
             reactants = rxn["reactant_names"]

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -466,7 +466,7 @@ class Pynta:
                 "constraints": ["freeze up to "+str(self.nslab)]}
 
         #logging.info
-          logger.info(f"================= IRC mode is: {self.irc_mode} =======================")
+        logger.info(f"================= IRC mode is: {self.irc_mode} =======================")
         #pass through 
         
         for i,rxn in enumerate(self.rxns_dict):

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -453,6 +453,7 @@ class Pynta:
         else:
             opt_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs_TS,
                 "run_kwargs": {"fmax" : 0.02, "steps" : 70},"constraints": ["freeze up to "+str(self.nslab)],"sella":True,"order":1,}
+        
         vib_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
                 "constraints": ["freeze up to "+str(self.nslab)]}
 
@@ -467,7 +468,7 @@ class Pynta:
                 print(f"======================================================================")
 
                 IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
-                    "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)]}
+                    "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to "+str(self.nslab)]}
 
                 ts_task = MolecularTSEstimate({"rxn": rxn,"ts_path": ts_path,"slab_path": self.slab_path,"adsorbates_path": os.path.join(self.path,"Adsorbates"),
                             "rxns_file": self.rxns_file,"path": self.path,"metal": self.metal,"facet": self.surface_type, "out_path": ts_path,

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -519,7 +519,7 @@ class Pynta:
                 fw = Firework([ts_task],parents=parents,name="TS"+str(i)+"est",spec={"_allow_fizzled_parents": True,"_priority": 10})
                 self.fws.append(fw)
 
-        print(f"irc_mode is: {self.irc_mode}, IRC_obj_dict: {IRC_obj_dict}")
+        print(f"irc_mode is: {self.irc_mode}")
 
     def launch(self,single_job=False):
         """

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -24,7 +24,7 @@ import logging
 
 #logger
 logger = logging.getLogger(__name__)
-logging.basicConfig(filename='pynta.log', encoding='utf-8', level=logging.INFO)
+logging.basicConfig(filename='pynta.log', level=logging.INFO)
 
 
 class Pynta:
@@ -490,7 +490,16 @@ class Pynta:
                 print("==Skip IRC: IRC is not conducted==")
                 logger.info("==Skip IRC: IRC is not conducted==")
                 pass
-
+            ts_path = os.path.join(self.path,"TS"+str(i))
+            os.makedirs(ts_path)
+            ts_task = MolecularTSEstimate({"rxn": rxn,"ts_path": ts_path,"slab_path": self.slab_path,"adsorbates_path": os.path.join(self.path,"Adsorbates"),
+                "rxns_file": self.rxns_file,"path": self.path,"metal": self.metal,"facet": self.surface_type, "out_path": ts_path, "irc_mode": self.irc_mode,
+                "spawn_jobs": True, "opt_obj_dict": opt_obj_dict, "vib_obj_dict": vib_obj_dict,
+                    "IRC_obj_dict": IRC_obj_dict, "nprocs": 48, "name_to_adjlist_dict": self.name_to_adjlist_dict,
+                    "gratom_to_molecule_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_atom_maps.items()},
+                    "gratom_to_molecule_surface_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_surface_atom_maps.items()},
+                    "nslab":self.nslab,"Eharmtol":self.Eharmtol,"Eharmfiltertol":self.Eharmfiltertol,"Ntsmin":self.Ntsmin,
+                    "max_num_hfsp_opts":self.max_num_hfsp_opts})
             reactants = rxn["reactant_names"]
             products = rxn["product_names"]
             parents = []

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -466,27 +466,21 @@ class Pynta:
                 "constraints": ["freeze up to "+str(self.nslab)]}
 
         #logging.info
-        print(f"================= IRC mode is: {self.irc_mode} =======================")
-        logger.info(f"================= IRC mode is: {self.irc_mode} =======================")
+          logger.info(f"================= IRC mode is: {self.irc_mode} =======================")
         #pass through 
         
         for i,rxn in enumerate(self.rxns_dict):
             #if irc_mode is "fixed" freeze all slab and conduct MolecularTSEstimate. 
             if self.irc_mode == "fixed":
-                print("==Entire slab layers are frozen==")
-                logging.info("Entire slab layers are frozen")
                 IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
                     "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to "+str(self.nslab)]}
 
             elif self.irc_mode == "relaxed":
-                print("==Top half of the slab is relaxed==")
-                logger.info("==Top half of the slab is relaxed==")
                 IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
                     "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)]}
         # if irc_mode = "skip" : do not conduct IRC
             else:
-                print("==Skip IRC: IRC is not conducted==")
-                logger.info("==Skip IRC: IRC is not conducted==")
+                logger.info("Skip IRC: IRC is not conducted")
                 IRC_obj_dict = {}
                 pass
 

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -478,13 +478,13 @@ class Pynta:
                 print("==Entire slab layers are frozen==")
                 logging.info("Entire slab layers are frozen")
                 IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
-                    "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to "+str(self.nslab)], irc_mode}
+                    "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to "+str(self.nslab)], "irc_mode":self.irc_mode}
 
             elif self.irc_mode == "relaxed":
                 print("==Top half of the slab is relaxed==")
                 logger.info("==Top half of the slab is relaxed==")
                 IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
-                "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)],irc_mode}
+                "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)],"irc_mode":self.irc_mode}
         # if irc_mode = "skip" : do not conduct IRC
             else:
                 print("==Skip IRC: IRC is not conducted==")

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -457,8 +457,10 @@ class Pynta:
         vib_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
                 "constraints": ["freeze up to "+str(self.nslab)]}
 
+        #logging.info
         print(f"================= IRC mode is: {self.irc_mode} =======================")
-
+        #pass through 
+        
         for i,rxn in enumerate(self.rxns_dict):
             ts_path = os.path.join(self.path,"TS"+str(i))
             os.makedirs(ts_path)
@@ -479,22 +481,16 @@ class Pynta:
             else:
                 print("Skip IRC: IRC is not conducted")
                 print(f"======================================================================")
-                ts_task = MolecularTSEstimate_noIRC({"rxn": rxn,"ts_path": ts_path,"slab_path": self.slab_path,"adsorbates_path": os.path.join(self.path,"Adsorbates"),
-                            "rxns_file": self.rxns_file,"path": self.path,"metal": self.metal,"facet": self.surface_type, "out_path": ts_path,
-                            "spawn_jobs": True, "opt_obj_dict": opt_obj_dict, "vib_obj_dict": vib_obj_dict,
-                            "nprocs": 48, "name_to_adjlist_dict": self.name_to_adjlist_dict,
-                            "gratom_to_molecule_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_atom_maps.items()},
-                            "gratom_to_molecule_surface_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_surface_atom_maps.items()},
-                            "nslab":self.nslab,"Eharmtol":self.Eharmtol,"Eharmfiltertol":self.Eharmfiltertol,"Ntsmin":self.Ntsmin,
-                            "max_num_hfsp_opts":self.max_num_hfsp_opts}) #delete irc_opt_dict
-                reactants = rxn["reactant_names"]
-                products = rxn["product_names"]
-                parents = []
-                if not adsorbates_finished:
-                    for m in reactants+products:
-                        parents.extend(self.adsorbate_fw_dict[m])
-                fw = Firework([ts_task],parents=parents,name="TS"+str(i)+"est",spec={"_allow_fizzled_parents": True,"_priority": 10})
-                self.fws.append(fw)
+                pass
+
+            reactants = rxn["reactant_names"]
+            products = rxn["product_names"]
+            parents = []
+            if not adsorbates_finished:
+                for m in reactants+products:
+                    parents.extend(self.adsorbate_fw_dict[m])
+            fw = Firework([ts_task],parents=parents,name="TS"+str(i)+"est",spec={"_allow_fizzled_parents": True,"_priority": 10})
+            self.fws.append(fw)
 
     def launch(self,single_job=False):
         """

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -466,6 +466,7 @@ class Pynta:
                 "constraints": ["freeze up to "+str(self.nslab)]}
 
         #logging.info
+        print(f"================= IRC mode is: {self.irc_mode} =======================")
         logger.info(f"================= IRC mode is: {self.irc_mode} =======================")
         #pass through 
         
@@ -474,17 +475,20 @@ class Pynta:
             os.makedirs(ts_path)
             #if irc_mode is "fixed" freeze all slab and conduct MolecularTSEstimate. 
             if self.irc_mode == "fixed":
+                print("==Entire slab layers are frozen==")
                 logging.info("Entire slab layers are frozen")
                 IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
-                    "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to "+str(self.nslab)]}
+                    "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to "+str(self.nslab)], irc_mode}
 
             elif self.irc_mode == "relaxed":
-                logger.info("Top half of the slab is relaxed")
+                print("==Top half of the slab is relaxed==")
+                logger.info("==Top half of the slab is relaxed==")
                 IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
-                "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)]}
+                "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)],irc_mode}
         # if irc_mode = "skip" : do not conduct IRC
             else:
-                logger.info("Skip IRC: IRC is not conducted")
+                print("==Skip IRC: IRC is not conducted==")
+                logger.info("==Skip IRC: IRC is not conducted==")
                 pass
 
             reactants = rxn["reactant_names"]

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -451,40 +451,75 @@ class Pynta:
                 "run_kwargs": {"fmax" : 0.02, "steps" : 70},"constraints": ["freeze up to "+str(self.nslab)],"sella":True,"order":1,}
         vib_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
                 "constraints": ["freeze up to "+str(self.nslab)]}
-        # if irc_mode = "fixed" : freeze all the slab
-        if self.irc_mode == "fixed":
-            IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
-                "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)]}
-        # if irc_mode = "relaxed" : freeze half of the slab
-        elif self.irc_mode == "relaxed":
-            IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
-                "run_kwargs": {"fmax" : self.fmaxirc, "steps" : 70},"constraints":["freeze up to "+str(self.nslab)]}
-        # if irc_mode = "skip" : do not conduct IRC
-        else:
-            print("Skip IRC: IRC is not conducted")
-            pass
-         
-        print(f"irc_mode is: {self.irc_mode}, IRC_obj_dict: {IRC_obj_dict}")
+
+        print(f"irc_mode is: {self.irc_mode}")
 
         for i,rxn in enumerate(self.rxns_dict):
             ts_path = os.path.join(self.path,"TS"+str(i))
             os.makedirs(ts_path)
-            ts_task = MolecularTSEstimate({"rxn": rxn,"ts_path": ts_path,"slab_path": self.slab_path,"adsorbates_path": os.path.join(self.path,"Adsorbates"),
-                "rxns_file": self.rxns_file,"path": self.path,"metal": self.metal,"facet": self.surface_type, "out_path": ts_path,
-                "spawn_jobs": True, "opt_obj_dict": opt_obj_dict, "vib_obj_dict": vib_obj_dict,
-                    "IRC_obj_dict": IRC_obj_dict, "nprocs": 48, "name_to_adjlist_dict": self.name_to_adjlist_dict,
-                    "gratom_to_molecule_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_atom_maps.items()},
-                    "gratom_to_molecule_surface_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_surface_atom_maps.items()},
-                    "nslab":self.nslab,"Eharmtol":self.Eharmtol,"Eharmfiltertol":self.Eharmfiltertol,"Ntsmin":self.Ntsmin,
-                    "max_num_hfsp_opts":self.max_num_hfsp_opts})
-            reactants = rxn["reactant_names"]
-            products = rxn["product_names"]
-            parents = []
-            if not adsorbates_finished:
-                for m in reactants+products:
-                    parents.extend(self.adsorbate_fw_dict[m])
-            fw = Firework([ts_task],parents=parents,name="TS"+str(i)+"est",spec={"_allow_fizzled_parents": True,"_priority": 10})
-            self.fws.append(fw)
+            #if irc_mode is "fixed" freeze all slab and conduct MolecularTSEstimate. 
+            if self.irc_mode == "fixed":
+                IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
+                    "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)]}
+
+                ts_task = MolecularTSEstimate({"rxn": rxn,"ts_path": ts_path,"slab_path": self.slab_path,"adsorbates_path": os.path.join(self.path,"Adsorbates"),
+                            "rxns_file": self.rxns_file,"path": self.path,"metal": self.metal,"facet": self.surface_type, "out_path": ts_path,
+                            "spawn_jobs": True, "opt_obj_dict": opt_obj_dict, "vib_obj_dict": vib_obj_dict,
+                            "IRC_obj_dict": IRC_obj_dict, "nprocs": 48, "name_to_adjlist_dict": self.name_to_adjlist_dict,
+                            "gratom_to_molecule_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_atom_maps.items()},
+                            "gratom_to_molecule_surface_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_surface_atom_maps.items()},
+                            "nslab":self.nslab,"Eharmtol":self.Eharmtol,"Eharmfiltertol":self.Eharmfiltertol,"Ntsmin":self.Ntsmin,
+                            "max_num_hfsp_opts":self.max_num_hfsp_opts})
+                reactants = rxn["reactant_names"]
+                products = rxn["product_names"]
+                parents = []
+                if not adsorbates_finished:
+                    for m in reactants+products:
+                        parents.extend(self.adsorbate_fw_dict[m])
+                fw = Firework([ts_task],parents=parents,name="TS"+str(i)+"est",spec={"_allow_fizzled_parents": True,"_priority": 10})
+                self.fws.append(fw)
+
+            elif self.irc_mode == "relaxed":
+                IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
+                "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)]}
+
+                ts_task = MolecularTSEstimate({"rxn": rxn,"ts_path": ts_path,"slab_path": self.slab_path,"adsorbates_path": os.path.join(self.path,"Adsorbates"),
+                            "rxns_file": self.rxns_file,"path": self.path,"metal": self.metal,"facet": self.surface_type, "out_path": ts_path,
+                            "spawn_jobs": True, "opt_obj_dict": opt_obj_dict, "vib_obj_dict": vib_obj_dict,
+                            "IRC_obj_dict": IRC_obj_dict, "nprocs": 48, "name_to_adjlist_dict": self.name_to_adjlist_dict,
+                            "gratom_to_molecule_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_atom_maps.items()},
+                            "gratom_to_molecule_surface_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_surface_atom_maps.items()},
+                            "nslab":self.nslab,"Eharmtol":self.Eharmtol,"Eharmfiltertol":self.Eharmfiltertol,"Ntsmin":self.Ntsmin,
+                            "max_num_hfsp_opts":self.max_num_hfsp_opts})
+                reactants = rxn["reactant_names"]
+                products = rxn["product_names"]
+                parents = []
+                if not adsorbates_finished:
+                    for m in reactants+products:
+                        parents.extend(self.adsorbate_fw_dict[m])
+                fw = Firework([ts_task],parents=parents,name="TS"+str(i)+"est",spec={"_allow_fizzled_parents": True,"_priority": 10})
+                self.fws.append(fw)
+        # if irc_mode = "skip" : do not conduct IRC
+            else:
+                print("Skip IRC: IRC is not conducted") 
+                ts_task = MolecularTSEstimate({"rxn": rxn,"ts_path": ts_path,"slab_path": self.slab_path,"adsorbates_path": os.path.join(self.path,"Adsorbates"),
+                            "rxns_file": self.rxns_file,"path": self.path,"metal": self.metal,"facet": self.surface_type, "out_path": ts_path,
+                            "spawn_jobs": True, "opt_obj_dict": opt_obj_dict, "vib_obj_dict": vib_obj_dict,
+                            "nprocs": 48, "name_to_adjlist_dict": self.name_to_adjlist_dict,
+                            "gratom_to_molecule_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_atom_maps.items()},
+                            "gratom_to_molecule_surface_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_surface_atom_maps.items()},
+                            "nslab":self.nslab,"Eharmtol":self.Eharmtol,"Eharmfiltertol":self.Eharmfiltertol,"Ntsmin":self.Ntsmin,
+                            "max_num_hfsp_opts":self.max_num_hfsp_opts}) #delete irc_opt_dict
+                reactants = rxn["reactant_names"]
+                products = rxn["product_names"]
+                parents = []
+                if not adsorbates_finished:
+                    for m in reactants+products:
+                        parents.extend(self.adsorbate_fw_dict[m])
+                fw = Firework([ts_task],parents=parents,name="TS"+str(i)+"est",spec={"_allow_fizzled_parents": True,"_priority": 10})
+                self.fws.append(fw)
+
+        print(f"irc_mode is: {self.irc_mode}, IRC_obj_dict: {IRC_obj_dict}")
 
     def launch(self,single_job=False):
         """

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -462,7 +462,8 @@ class Pynta:
         # if irc_mode = "skip" : do not conduct IRC
         if self.irc_mode == "skip":
             print("Skip IRC: IRC is not conducted")
-            
+         
+        print(f"irc_mode is: {self.irc_mode}, IRC_obj_dict: {IRC_obj_dict}")
 
         for i,rxn in enumerate(self.rxns_dict):
             ts_path = os.path.join(self.path,"TS"+str(i))

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -485,6 +485,7 @@ class Pynta:
                     "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)]}
         # if irc_mode = "skip" : do not conduct IRC
             else:
+                self.irc_mode = "skip"
                 print("==Skip IRC: IRC is not conducted==")
                 logger.info("==Skip IRC: IRC is not conducted==")
 
@@ -492,7 +493,7 @@ class Pynta:
             os.makedirs(ts_path)
             ts_task = MolecularTSEstimate({"rxn": rxn,"ts_path": ts_path,"slab_path": self.slab_path,"adsorbates_path": os.path.join(self.path,"Adsorbates"),
                     "rxns_file": self.rxns_file,"path": self.path,"metal": self.metal,"facet": self.surface_type, "out_path": ts_path, "irc_mode": self.irc_mode,
-                    "spawn_jobs": True, "opt_obj_dict": opt_obj_dict, "vib_obj_dict": vib_obj_dict, "IRC_obj_dict": IRC_obj_dict,
+                    "spawn_jobs": True, "opt_obj_dict": opt_obj_dict, "vib_obj_dict": vib_obj_dict,
                     "nprocs": 48, "name_to_adjlist_dict": self.name_to_adjlist_dict,
                     "gratom_to_molecule_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_atom_maps.items()},
                     "gratom_to_molecule_surface_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_surface_atom_maps.items()},

--- a/pynta/main.py
+++ b/pynta/main.py
@@ -463,6 +463,9 @@ class Pynta:
             os.makedirs(ts_path)
             #if irc_mode is "fixed" freeze all slab and conduct MolecularTSEstimate. 
             if self.irc_mode == "fixed":
+                print("Entire slab layers are frozen")
+                print(f"======================================================================")
+
                 IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
                     "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)]}
 
@@ -484,6 +487,8 @@ class Pynta:
                 self.fws.append(fw)
 
             elif self.irc_mode == "relaxed":
+                print("Top half of the slab is relaxed")
+                print(f"======================================================================")
                 IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
                 "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)]}
 
@@ -505,7 +510,8 @@ class Pynta:
                 self.fws.append(fw)
         # if irc_mode = "skip" : do not conduct IRC
             else:
-                print("Skip IRC: IRC is not conducted") 
+                print("Skip IRC: IRC is not conducted")
+                print(f"======================================================================")
                 ts_task = MolecularTSEstimate_noIRC({"rxn": rxn,"ts_path": ts_path,"slab_path": self.slab_path,"adsorbates_path": os.path.join(self.path,"Adsorbates"),
                             "rxns_file": self.rxns_file,"path": self.path,"metal": self.metal,"facet": self.surface_type, "out_path": ts_path,
                             "spawn_jobs": True, "opt_obj_dict": opt_obj_dict, "vib_obj_dict": vib_obj_dict,

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -638,6 +638,11 @@ class MolecularTSEstimate(FiretaskBase):
                 return FWAction(detours=newwf) #using detour allows us to inherit children from the original collect to the subsequent collects
         else:
             return FWAction()
+            
+def collect_firework(xyzs,check_symm,fw_generators,fw_generator_dicts,out_names,future_check_symms,parents=[],label="",allow_fizzled_parents=False):
+    task = MolecularCollect({"xyzs": xyzs, "check_symm": check_symm, "fw_generators": fw_generators,
+        "fw_generator_dicts": fw_generator_dicts, "out_names": out_names, "future_check_symms": future_check_symms, "label": label})
+    return Firework([task],parents=parents,name=label+"collect",spec={"_allow_fizzled_parents": allow_fizzled_parents,"_priority": 5})
 
 @explicit_serialize
 class MolecularCollect(CollectTask):

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -779,7 +779,7 @@ class MolecularTSEstimate_noIRC(FiretaskBase):
                 xyzsout.append(xyzs[Eind])
 
         if spawn_jobs:
-            ctask = MolecularCollect({"xyzs":xyzsout,"check_symm":True,"fw_generators": ["optimize_firework",["vibrations_firework","IRC_firework","IRC_firework"]],
+            ctask = MolecularCollect({"xyzs":xyzsout,"check_symm":True,"fw_generators": ["optimize_firework",["vibrations_firework"]],
                 "fw_generator_dicts": [self["opt_obj_dict"],[self["vib_obj_dict"]]],
                     "out_names": ["opt.xyz",["vib.json","irc_forward.traj","irc_reverse.traj"]],"future_check_symms": [True,False], "label": "TS"+str(index)+"_"+rxn_name})
             cfw = Firework([ctask],name="TS"+str(index)+"_"+rxn_name+"_collect",spec={"_allow_fizzled_parents": True, "_priority": 5})
@@ -886,10 +886,10 @@ class MolecularTSNudge(FiretaskBase):
         else:
             return FWAction()
 
-def IRC_firework(xyz,label,out_path=None,spawn_jobs=False,software=None,irc_mode,
+def IRC_firework(xyz,label,out_path=None,spawn_jobs=False,software=None,
         socket=False,software_kwargs={},opt_kwargs={},run_kwargs={},constraints=[],parents=[],ignore_errors=False,forward=True):
         if out_path is None: out_path = os.path.join(directory,label+"_irc.traj")
-        t1 = MolecularIRC(xyz=xyz,label=label,software=software,irc_mode=irc_mode,
+        t1 = MolecularIRC(xyz=xyz,label=label,software=software,
             socket=socket,software_kwargs=software_kwargs,opt_kwargs=opt_kwargs,run_kwargs=run_kwargs,
             constraints=constraints,ignore_errors=ignore_errors,forward=forward)
         t2 = FileTransferTask({'files': [{'src': label+'_irc.traj', 'dest': out_path}], 'mode': 'copy', 'ignore_errors' : ignore_errors})
@@ -898,7 +898,7 @@ def IRC_firework(xyz,label,out_path=None,spawn_jobs=False,software=None,irc_mode
 
 @explicit_serialize
 class MolecularIRC(FiretaskBase):
-    required_params = ["xyz","label","irc_mode"]
+    required_params = ["xyz","label"]
     optional_params = ["software","socket",
             "software_kwargs", "opt_kwargs", "run_kwargs", "constraints", "ignore_errors", "forward"]
     def run_task(self, fw_spec):

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -615,7 +615,8 @@ class MolecularTSEstimate(FiretaskBase):
                 xyzsout.append(xyzs[Eind])
 
         if spawn_jobs:
-            if self.[irc_mode] == "skip":
+            print(irc_mode)
+            if irc_mode == "skip":
                 ctask = MolecularCollect({"xyzs":xyzsout,"check_symm":True,"fw_generators": ["optimize_firework",["vibrations_firework"]],
                         "fw_generator_dicts": [self["opt_obj_dict"],[self["vib_obj_dict"]]],
                         "out_names": ["opt.xyz",["vib.json"]],"future_check_symms": [True,False], "label": "TS"+str(index)+"_"+rxn_name})

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -615,18 +615,26 @@ class MolecularTSEstimate(FiretaskBase):
                 xyzsout.append(xyzs[Eind])
 
         if spawn_jobs:
-            if irc_mode == ""
-            irc_obj_dict_forward = deepcopy(self["IRC_obj_dict"])
-            irc_obj_dict_forward["forward"] = True
-            irc_obj_dict_reverse = deepcopy(self["IRC_obj_dict"])
-            irc_obj_dict_reverse["forward"] = False
+            if self.[irc_mode] == "skip":
+                ctask = MolecularCollect({"xyzs":xyzsout,"check_symm":True,"fw_generators": ["optimize_firework",["vibrations_firework"]],
+                        "fw_generator_dicts": [self["opt_obj_dict"],[self["vib_obj_dict"]]],
+                        "out_names": ["opt.xyz",["vib.json"]],"future_check_symms": [True,False], "label": "TS"+str(index)+"_"+rxn_name})
+                cfw = Firework([ctask],name="TS"+str(index)+"_"+rxn_name+"_collect",spec={"_allow_fizzled_parents": True, "_priority": 5})
+                newwf = Workflow([cfw],name='rxn_'+str(index)+str(rxn_name))
+                return FWAction(detours=newwf) #using detour allows us to inherit children from the original collect to the subsequent collects
 
-            ctask = MolecularCollect({"xyzs":xyzsout,"check_symm":True,"fw_generators": ["optimize_firework",["vibrations_firework","IRC_firework","IRC_firework"]],
-                "fw_generator_dicts": [self["opt_obj_dict"],[self["vib_obj_dict"],irc_obj_dict_forward,irc_obj_dict_reverse]],
+            else:
+                irc_obj_dict_forward = deepcopy(self["IRC_obj_dict"])
+                irc_obj_dict_forward["forward"] = True
+                irc_obj_dict_reverse = deepcopy(self["IRC_obj_dict"])
+                irc_obj_dict_reverse["forward"] = False
+
+                ctask = MolecularCollect({"xyzs":xyzsout,"check_symm":True,"fw_generators": ["optimize_firework",["vibrations_firework","IRC_firework","IRC_firework"]],
+                    "fw_generator_dicts": [self["opt_obj_dict"],[self["vib_obj_dict"],irc_obj_dict_forward,irc_obj_dict_reverse]],
                     "out_names": ["opt.xyz",["vib.json","irc_forward.traj","irc_reverse.traj"]],"future_check_symms": [True,False], "label": "TS"+str(index)+"_"+rxn_name})
-            cfw = Firework([ctask],name="TS"+str(index)+"_"+rxn_name+"_collect",spec={"_allow_fizzled_parents": True, "_priority": 5})
-            newwf = Workflow([cfw],name='rxn_'+str(index)+str(rxn_name))
-            return FWAction(detours=newwf) #using detour allows us to inherit children from the original collect to the subsequent collects
+                cfw = Firework([ctask],name="TS"+str(index)+"_"+rxn_name+"_collect",spec={"_allow_fizzled_parents": True, "_priority": 5})
+                newwf = Workflow([cfw],name='rxn_'+str(index)+str(rxn_name))
+                return FWAction(detours=newwf) #using detour allows us to inherit children from the original collect to the subsequent collects
         else:
             return FWAction()
 

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -470,7 +470,7 @@ class MolecularTSEstimate(FiretaskBase):
                         "name_to_adjlist_dict", "gratom_to_molecule_atom_maps",
                         "gratom_to_molecule_surface_atom_maps","irc_mode",
                         "vib_obj_dict","opt_obj_dict","nslab","Eharmtol","Eharmfiltertol","Ntsmin","max_num_hfsp_opts"]
-    optional_params = ["out_path","spawn_jobs","nprocs"]
+    optional_params = ["out_path","spawn_jobs","nprocs","IRC_obj_dict"]
     def run_task(self, fw_spec):
         gratom_to_molecule_atom_maps = {sm: {int(k):v for k,v in d.items()} for sm,d in self["gratom_to_molecule_atom_maps"].items()}
         gratom_to_molecule_surface_atom_maps = {sm: {int(k):v for k,v in d.items()} for sm,d in self["gratom_to_molecule_surface_atom_maps"].items()}

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -616,7 +616,8 @@ class MolecularTSEstimate(FiretaskBase):
                 xyzsout.append(xyzs[Eind])
 
         if spawn_jobs:
-            if self.[irc_mode] == "skip":
+            print(irc_mode)
+            if irc_mode == "skip":
                 ctask = MolecularCollect({"xyzs":xyzsout,"check_symm":True,"fw_generators": ["optimize_firework",["vibrations_firework"]],
                         "fw_generator_dicts": [self["opt_obj_dict"],[self["vib_obj_dict"]]],
                         "out_names": ["opt.xyz",["vib.json"]],"future_check_symms": [True,False], "label": "TS"+str(index)+"_"+rxn_name})
@@ -638,6 +639,11 @@ class MolecularTSEstimate(FiretaskBase):
                 return FWAction(detours=newwf) #using detour allows us to inherit children from the original collect to the subsequent collects
         else:
             return FWAction()
+            
+def collect_firework(xyzs,check_symm,fw_generators,fw_generator_dicts,out_names,future_check_symms,parents=[],label="",allow_fizzled_parents=False):
+    task = MolecularCollect({"xyzs": xyzs, "check_symm": check_symm, "fw_generators": fw_generators,
+        "fw_generator_dicts": fw_generator_dicts, "out_names": out_names, "future_check_symms": future_check_symms, "label": label})
+    return Firework([task],parents=parents,name=label+"collect",spec={"_allow_fizzled_parents": allow_fizzled_parents,"_priority": 5})
 
 def collect_firework(xyzs,check_symm,fw_generators,fw_generator_dicts,out_names,future_check_symms,parents=[],label="",allow_fizzled_parents=False):
     task = MolecularCollect({"xyzs": xyzs, "check_symm": check_symm, "fw_generators": fw_generators,

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -646,11 +646,6 @@ def collect_firework(xyzs,check_symm,fw_generators,fw_generator_dicts,out_names,
         "fw_generator_dicts": fw_generator_dicts, "out_names": out_names, "future_check_symms": future_check_symms, "label": label})
     return Firework([task],parents=parents,name=label+"collect",spec={"_allow_fizzled_parents": allow_fizzled_parents,"_priority": 5})
 
-def collect_firework(xyzs,check_symm,fw_generators,fw_generator_dicts,out_names,future_check_symms,parents=[],label="",allow_fizzled_parents=False):
-    task = MolecularCollect({"xyzs": xyzs, "check_symm": check_symm, "fw_generators": fw_generators,
-        "fw_generator_dicts": fw_generator_dicts, "out_names": out_names, "future_check_symms": future_check_symms, "label": label})
-    return Firework([task],parents=parents,name=label+"collect",spec={"_allow_fizzled_parents": allow_fizzled_parents,"_priority": 5})
-
 @explicit_serialize
 class MolecularCollect(CollectTask):
     required_params = ["xyzs","check_symm","fw_generators","fw_generator_dicts","out_names","future_check_symms","label"]

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -470,7 +470,7 @@ class MolecularTSEstimate(FiretaskBase):
                         "name_to_adjlist_dict", "gratom_to_molecule_atom_maps",
                         "gratom_to_molecule_surface_atom_maps","irc_mode",
                         "vib_obj_dict","opt_obj_dict","nslab","Eharmtol","Eharmfiltertol","Ntsmin","max_num_hfsp_opts"]
-    optional_params = ["out_path","spawn_jobs","nprocs","IRC_obj_dict"]
+    optional_params = ["out_path","spawn_jobs","nprocs"]
     def run_task(self, fw_spec):
         gratom_to_molecule_atom_maps = {sm: {int(k):v for k,v in d.items()} for sm,d in self["gratom_to_molecule_atom_maps"].items()}
         gratom_to_molecule_surface_atom_maps = {sm: {int(k):v for k,v in d.items()} for sm,d in self["gratom_to_molecule_surface_atom_maps"].items()}
@@ -617,15 +617,7 @@ class MolecularTSEstimate(FiretaskBase):
 
         if spawn_jobs:
             print(irc_mode)
-            if irc_mode == "skip":
-                ctask = MolecularCollect({"xyzs":xyzsout,"check_symm":True,"fw_generators": ["optimize_firework",["vibrations_firework"]],
-                        "fw_generator_dicts": [self["opt_obj_dict"],[self["vib_obj_dict"]]],
-                        "out_names": ["opt.xyz",["vib.json"]],"future_check_symms": [True,False], "label": "TS"+str(index)+"_"+rxn_name})
-                cfw = Firework([ctask],name="TS"+str(index)+"_"+rxn_name+"_collect",spec={"_allow_fizzled_parents": True, "_priority": 5})
-                newwf = Workflow([cfw],name='rxn_'+str(index)+str(rxn_name))
-                return FWAction(detours=newwf) #using detour allows us to inherit children from the original collect to the subsequent collects
-
-            else:
+            if irc_mode == "relaxed" or irc_mode == "fixed":
                 irc_obj_dict_forward = deepcopy(self["IRC_obj_dict"])
                 irc_obj_dict_forward["forward"] = True
                 irc_obj_dict_reverse = deepcopy(self["IRC_obj_dict"])
@@ -637,9 +629,18 @@ class MolecularTSEstimate(FiretaskBase):
                 cfw = Firework([ctask],name="TS"+str(index)+"_"+rxn_name+"_collect",spec={"_allow_fizzled_parents": True, "_priority": 5})
                 newwf = Workflow([cfw],name='rxn_'+str(index)+str(rxn_name))
                 return FWAction(detours=newwf) #using detour allows us to inherit children from the original collect to the subsequent collects
+                
+            #if irc_mode == "skip":
+            else:
+                ctask = MolecularCollect({"xyzs":xyzsout,"check_symm":True,"fw_generators": ["optimize_firework",["vibrations_firework"]],
+                        "fw_generator_dicts": [self["opt_obj_dict"],[self["vib_obj_dict"]]],
+                        "out_names": ["opt.xyz",["vib.json"]],"future_check_symms": [True,False], "label": "TS"+str(index)+"_"+rxn_name})
+                cfw = Firework([ctask],name="TS"+str(index)+"_"+rxn_name+"_collect",spec={"_allow_fizzled_parents": True, "_priority": 5})
+                newwf = Workflow([cfw],name='rxn_'+str(index)+str(rxn_name))
+                return FWAction(detours=newwf) #using detour allows us to inherit children from the original collect to the subsequent collects
         else:
             return FWAction()
-            
+
 def collect_firework(xyzs,check_symm,fw_generators,fw_generator_dicts,out_names,future_check_symms,parents=[],label="",allow_fizzled_parents=False):
     task = MolecularCollect({"xyzs": xyzs, "check_symm": check_symm, "fw_generators": fw_generators,
         "fw_generator_dicts": fw_generator_dicts, "out_names": out_names, "future_check_symms": future_check_symms, "label": label})

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -468,9 +468,9 @@ class MolecularVibrationsTask(VibrationTask):
 class MolecularTSEstimate(FiretaskBase):
     required_params = ["rxn","ts_path","slab_path","adsorbates_path","rxns_file","path","metal","facet",
                         "name_to_adjlist_dict", "gratom_to_molecule_atom_maps",
-                        "gratom_to_molecule_surface_atom_maps","opt_obj_dict",
-                                "vib_obj_dict","IRC_obj_dict","nslab","Eharmtol","Eharmfiltertol","Ntsmin","max_num_hfsp_opts"]
-    optional_params = ["out_path","spawn_jobs","nprocs",]
+                        "gratom_to_molecule_surface_atom_maps","irc_mode",
+                        "vib_obj_dict","opt_obj_dict","nslab","Eharmtol","Eharmfiltertol","Ntsmin","max_num_hfsp_opts"]
+    optional_params = ["out_path","spawn_jobs","nprocs","IRC_obj_dict"]
     def run_task(self, fw_spec):
         gratom_to_molecule_atom_maps = {sm: {int(k):v for k,v in d.items()} for sm,d in self["gratom_to_molecule_atom_maps"].items()}
         gratom_to_molecule_surface_atom_maps = {sm: {int(k):v for k,v in d.items()} for sm,d in self["gratom_to_molecule_surface_atom_maps"].items()}
@@ -490,6 +490,7 @@ class MolecularTSEstimate(FiretaskBase):
         max_num_hfsp_opts = self["max_num_hfsp_opts"]
         slab_path = self["slab_path"]
         slab = read(slab_path)
+        irc_mode = self["irc_mode"]
 
         cas = SlabAdsorptionSites(slab,facet,allow_6fold=False,composition_effect=False,
                             label_sites=True,
@@ -614,6 +615,7 @@ class MolecularTSEstimate(FiretaskBase):
                 xyzsout.append(xyzs[Eind])
 
         if spawn_jobs:
+            if irc_mode == ""
             irc_obj_dict_forward = deepcopy(self["IRC_obj_dict"])
             irc_obj_dict_forward["forward"] = True
             irc_obj_dict_reverse = deepcopy(self["IRC_obj_dict"])
@@ -627,171 +629,6 @@ class MolecularTSEstimate(FiretaskBase):
             return FWAction(detours=newwf) #using detour allows us to inherit children from the original collect to the subsequent collects
         else:
             return FWAction()
-
-
-@explicit_serialize
-class MolecularTSEstimate_noIRC(FiretaskBase):
-    required_params = ["rxn","ts_path","slab_path","adsorbates_path","rxns_file","path","metal","facet",
-                        "name_to_adjlist_dict", "gratom_to_molecule_atom_maps",
-                        "gratom_to_molecule_surface_atom_maps","opt_obj_dict",
-                                "vib_obj_dict","nslab","Eharmtol","Eharmfiltertol","Ntsmin","max_num_hfsp_opts"]
-    optional_params = ["out_path","spawn_jobs","nprocs",]
-    def run_task(self, fw_spec):
-        gratom_to_molecule_atom_maps = {sm: {int(k):v for k,v in d.items()} for sm,d in self["gratom_to_molecule_atom_maps"].items()}
-        gratom_to_molecule_surface_atom_maps = {sm: {int(k):v for k,v in d.items()} for sm,d in self["gratom_to_molecule_surface_atom_maps"].items()}
-        out_path = self["out_path"] if "out_path" in self.keys() else ts_path
-        spawn_jobs = self["spawn_jobs"] if "spawn_jobs" in self.keys() else False
-        nprocs = self["nprocs"] if "nprocs" in self.keys() else 1
-
-        ts_path = self["ts_path"]
-        rxn = self["rxn"]
-        index = rxn["index"]
-        metal = self["metal"]
-        facet = self["facet"]
-        nslab = self["nslab"]
-        Eharmtol = self["Eharmtol"]
-        Eharmfiltertol = self["Eharmfiltertol"]
-        Ntsmin = self["Ntsmin"]
-        max_num_hfsp_opts = self["max_num_hfsp_opts"]
-        slab_path = self["slab_path"]
-        slab = read(slab_path)
-
-        cas = SlabAdsorptionSites(slab,facet,allow_6fold=False,composition_effect=False,
-                            label_sites=True,
-                            surrogate_metal=metal)
-
-        adsorbates_path = self["adsorbates_path"]
-
-
-        reactants = Molecule().from_adjacency_list(rxn["reactant"])
-        reactants.multiplicity = reactants.get_radical_count() + 1
-        products = Molecule().from_adjacency_list(rxn["product"])
-        products.multiplicity = products.get_radical_count() + 1
-
-        reactant_names = rxn["reactant_names"]
-        product_names = rxn["product_names"]
-        rxn_name = rxn["reaction"]
-
-        mol_dict = {name: Molecule().from_adjacency_list(adj.replace("multiplicity -187","")) for name,adj in self["name_to_adjlist_dict"].items()}
-
-        for sm,mol in mol_dict.items():
-            mol.multiplicity = mol.get_radical_count() + 1
-
-        reactant_mols = [mol_dict[name] for name in reactant_names]
-        product_mols = [mol_dict[name] for name in product_names]
-
-        adsorbates = get_unique_optimized_adsorbates(rxn,adsorbates_path,mol_dict,cas,gratom_to_molecule_surface_atom_maps,nslab)
-
-        forward,species_names = determine_TS_construction(reactant_names,
-                    reactant_mols,product_names,product_mols)
-
-        ordered_adsorbates = [adsorbates[name] for name in species_names]
-
-        rnum_surf_sites = [len(mol.get_surface_sites()) for i,mol in enumerate(reactant_mols)]
-        pnum_surf_sites = [len(mol.get_surface_sites()) for i,mol in enumerate(product_mols)]
-
-        ts_dict = {"forward": forward, "name": rxn_name, "reactants": reactants.to_adjacency_list(), "products": products.to_adjacency_list(),
-            "species_names": species_names, "nslab": nslab}
-
-        if forward:
-            num_surf_sites = rnum_surf_sites
-            reverse_names = product_names
-        else:
-            temp = products
-            products = reactants
-            reactants = temp
-            num_surf_sites = pnum_surf_sites
-            reverse_names = reactant_names
-
-        mols = [mol_dict[name] for name in species_names]
-        ts_dict["mols"] = [mol.to_adjacency_list() for mol in mols]
-        ts_dict["ads_sizes"] = [ads_size(mol) for mol in mols]
-        template_mol_map = get_template_mol_map(reactants,mols)
-        ts_dict["template_mol_map"] = template_mol_map
-        ts_dict["reverse_names"] = reverse_names
-        ts_dict["molecule_to_atom_maps"] = [{value:key for key,value in gratom_to_molecule_atom_maps[name].items()} for name in species_names]
-
-        with open(os.path.join(ts_path,"info.json"),'w') as f:
-            json.dump(ts_dict,f)
-
-        molecule_to_atom_maps = [{value:key for key,value in gratom_to_molecule_atom_maps[name].items()} for name in species_names]
-        template_to_ase = {i:get_ase_index(i,template_mol_map,molecule_to_atom_maps,
-                    nslab,[ads_size(mol) for mol in mols]) for i in range(len(reactants.atoms))}
-        ase_to_mol_num = {}
-        for tind,aind in template_to_ase.items():
-            if aind:
-                for i,mol_map in enumerate(template_mol_map):
-                    if tind in mol_map.keys():
-                        ase_to_mol_num[aind] = i
-                        break
-
-        tsstructs = get_unique_TS_structs(adsorbates,species_names,slab,cas,nslab,num_surf_sites,mol_dict,
-                                 gratom_to_molecule_atom_maps,gratom_to_molecule_surface_atom_maps,
-                                 facet,metal)
-
-        print("number of TS guesses pre-empty-sites:")
-        print(len(tsstructs))
-
-        tsstructs_out,constraint_lists,atom_bond_potential_lists,site_bond_potential_lists,site_bond_dict_list = generate_constraints_harmonic_parameters(
-                                            tsstructs,adsorbates,slab,reactants,
-                                             products,rxn["reaction_family"],template_reversed=(not forward),
-                                            ordered_names=species_names,reverse_names=reverse_names,
-                                            mol_dict=mol_dict,gratom_to_molecule_atom_maps=gratom_to_molecule_atom_maps,
-                                            gratom_to_molecule_surface_atom_maps=gratom_to_molecule_surface_atom_maps,
-                                            nslab=nslab,facet=facet,metal=metal,cas=cas)
-
-
-        out_tsstructs,new_atom_bond_potential_lists,new_site_bond_potential_lists,new_constraint_lists = get_surface_forming_bond_pairings(
-                            tsstructs_out,atom_bond_potential_lists,site_bond_potential_lists,constraint_lists,site_bond_dict_list,cas)
-
-        print("number of TS guesses with empty sites:")
-        print(len(out_tsstructs))
-
-        if max_num_hfsp_opts:
-            inds = index_site_bond_potential_lists_by_site_distances(new_site_bond_potential_lists)[:max_num_hfsp_opts].tolist()
-            out_tsstructs = [out_tsstructs[ind] for ind in inds]
-            new_atom_bond_potential_lists = [new_atom_bond_potential_lists[ind] for ind in inds]
-            new_site_bond_potential_lists = [new_site_bond_potential_lists[ind] for ind in inds]
-            new_constraint_lists = [new_constraint_lists[ind] for ind in inds]
-            print("number of TS guesses after filtering by max distance between sites")
-            print(len(out_tsstructs))
-
-        inputs = [ (out_tsstructs[j],new_atom_bond_potential_lists[j],new_site_bond_potential_lists[j],nslab,new_constraint_lists[j],ts_path,j,molecule_to_atom_maps,ase_to_mol_num) for j in range(len(out_tsstructs))]
-
-        #with mp.Pool(nprocs) as pool:
-        #    outputs = pool.map(map_harmonically_forced_xtb,inputs)
-        outputs = list(map(map_harmonically_forced_xtb,inputs))
-
-        xyzs = [output[2] for output in outputs if output[0]]
-        Es = [output[1] for output in outputs if output[0]]
-
-        xyzs,Es = filter_nonunique_TS_guess_indices(xyzs,Es) #remove identical guesses (that will just get filtered out later in the collect resulting in less guesses)
-
-        Einds = np.argsort(np.array(Es))
-        Emin = np.min(np.array(Es))
-        xyzsout = []
-        for Eind in Einds:
-            if Es[Eind]/Emin < Eharmtol: #include all TSs with energy close to Emin
-                xyzsout.append(xyzs[Eind])
-            elif Es[Eind]/Emin > Eharmfiltertol: #if the energy is much larger than Emin skip it
-                continue
-            elif len(xyzsout) < Ntsmin: #if the energy isn't similar, but isn't much larger include the smallest until Ntsmin is reached
-                xyzsout.append(xyzs[Eind])
-
-        if spawn_jobs:
-            ctask = MolecularCollect({"xyzs":xyzsout,"check_symm":True,"fw_generators": ["optimize_firework",["vibrations_firework"]],
-                "fw_generator_dicts": [self["opt_obj_dict"],[self["vib_obj_dict"]]],
-                    "out_names": ["opt.xyz",["vib.json","irc_forward.traj","irc_reverse.traj"]],"future_check_symms": [True,False], "label": "TS"+str(index)+"_"+rxn_name})
-            cfw = Firework([ctask],name="TS"+str(index)+"_"+rxn_name+"_collect",spec={"_allow_fizzled_parents": True, "_priority": 5})
-            newwf = Workflow([cfw],name='rxn_'+str(index)+str(rxn_name))
-            return FWAction(detours=newwf) #using detour allows us to inherit children from the original collect to the subsequent collects
-        else:
-            return FWAction()
-
-def collect_firework(xyzs,check_symm,fw_generators,fw_generator_dicts,out_names,future_check_symms,parents=[],label="",allow_fizzled_parents=False):
-    task = MolecularCollect({"xyzs": xyzs, "check_symm": check_symm, "fw_generators": fw_generators,
-        "fw_generator_dicts": fw_generator_dicts, "out_names": out_names, "future_check_symms": future_check_symms, "label": label})
-    return Firework([task],parents=parents,name=label+"collect",spec={"_allow_fizzled_parents": allow_fizzled_parents,"_priority": 5})
 
 @explicit_serialize
 class MolecularCollect(CollectTask):


### PR DESCRIPTION
**Summary of modification** 

I have updated the way of running IRC by user's choice. 
In pynta class from main.py, the keyword `irc_mode` is added. User can add this keyword in Pynta input script.
If `irc_mode = "relaxed"`, irc is calculated with top half of the slab layers relaxed. `irc_obj_dict` updated accordingly.
If `irc_mode = "fixed"`, irc is calculated with all slab layers frozen. `irc_obj_dict` updated accordingly.
If `irc_mode`, is not "relaxed" nor "fixed", IRC is not calculated. It will call `MolecularTSEstimate_noIRC` in tasks.py 

------------------------------------------------------------------------------------------------------------------------
**Updated comments (04/15/2024)** 

- I added logging.info() in main.py and `setup_transition_states()`. This will generate pynta.log file and dump info, which file and module via `logging.info`, firetasks are running. It is only implemented in `setup_transition_states()` at the moment as a test. But will be expanded throughout pynta. print() statement is still there to parse the output to job output file generated by slurm.
- Made `IRC_obj_dict` as optional keyword for `MolecularTSEstimate `


  
