### PR TITLE
Pynta calculate IRC in different mode by user's choice 

### DIFF
--- a/docsrc/README.rst
+++ b/docsrc/README.rst
@@ -256,6 +256,7 @@ An example python script for calling Pynta is available below.
                             }, },
         software_kwargs_gas=None,
         TS_opt_software_kwargs=None,
+        irc_mode="fixed",
         lattice_opt_software_kwargs={'kpts': (25,25,25), 'ecutwfc': 70, 'degauss':0.02, 'mixing_mode': 'plain'},
         reset_launchpad=False,queue_adapter_path=None,num_jobs=25,
         Eharmtol=3.0,Eharmfiltertol=30.0,Ntsmin=5,frozen_layers=2)
@@ -308,6 +309,14 @@ specified in terms of what `ASE <https://wiki.fysik.dtu.dk/ase/>`_ expects.
 **software_kwargs_gas**: this is a dictionary of keyword arguments that should be different from software_kwargs when running gas phase calculations
 
 **TS_opt_software_kwargs**: this is a dictionary of keyword arguments that should be different from software_kwargs when running saddle point optimizations
+
+**irc_mode**: mode to run IRC calculations. 
+
+If irc_mode is "fixed", entire slab layers are fixed. 
+
+If irc_mode is "relaxed", bottom half of slab layers are fixed and top half of slab layers are relaxed.
+
+If irc_mode is not "fixed" nor "relaxed", IRC is not calculated.
 
 **lattice_opt_software_kwargs**: this is a dictionary of keyword arguments that should be different from software_kwargs when optimizing the lattice constant
 

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -468,15 +468,16 @@ class MolecularVibrationsTask(VibrationTask):
 class MolecularTSEstimate(FiretaskBase):
     required_params = ["rxn","ts_path","slab_path","adsorbates_path","rxns_file","path","metal","facet",
                         "name_to_adjlist_dict", "gratom_to_molecule_atom_maps",
-                        "gratom_to_molecule_surface_atom_maps","opt_obj_dict",
-                                "vib_obj_dict","IRC_obj_dict","nslab","Eharmtol","Eharmfiltertol","Ntsmin","max_num_hfsp_opts"]
-    optional_params = ["out_path","spawn_jobs","nprocs",]
+                        "gratom_to_molecule_surface_atom_maps","irc_mode",
+                        "vib_obj_dict","opt_obj_dict","nslab","Eharmtol","Eharmfiltertol","Ntsmin","max_num_hfsp_opts"]
+    optional_params = ["out_path","spawn_jobs","nprocs","IRC_obj_dict"]
     def run_task(self, fw_spec):
         gratom_to_molecule_atom_maps = {sm: {int(k):v for k,v in d.items()} for sm,d in self["gratom_to_molecule_atom_maps"].items()}
         gratom_to_molecule_surface_atom_maps = {sm: {int(k):v for k,v in d.items()} for sm,d in self["gratom_to_molecule_surface_atom_maps"].items()}
         out_path = self["out_path"] if "out_path" in self.keys() else ts_path
         spawn_jobs = self["spawn_jobs"] if "spawn_jobs" in self.keys() else False
         nprocs = self["nprocs"] if "nprocs" in self.keys() else 1
+        IRC_obj_dict = self["IRC_obj_dict"] if "IRC_obj_dict" in self.keys() else None
 
         ts_path = self["ts_path"]
         rxn = self["rxn"]
@@ -490,6 +491,7 @@ class MolecularTSEstimate(FiretaskBase):
         max_num_hfsp_opts = self["max_num_hfsp_opts"]
         slab_path = self["slab_path"]
         slab = read(slab_path)
+        irc_mode = self["irc_mode"]
 
         cas = SlabAdsorptionSites(slab,facet,allow_6fold=False,composition_effect=False,
                             label_sites=True,
@@ -614,17 +616,27 @@ class MolecularTSEstimate(FiretaskBase):
                 xyzsout.append(xyzs[Eind])
 
         if spawn_jobs:
-            irc_obj_dict_forward = deepcopy(self["IRC_obj_dict"])
-            irc_obj_dict_forward["forward"] = True
-            irc_obj_dict_reverse = deepcopy(self["IRC_obj_dict"])
-            irc_obj_dict_reverse["forward"] = False
+            if irc_mode == "relaxed" or irc_mode == "fixed":
+                irc_obj_dict_forward = deepcopy(self["IRC_obj_dict"])
+                irc_obj_dict_forward["forward"] = True
+                irc_obj_dict_reverse = deepcopy(self["IRC_obj_dict"])
+                irc_obj_dict_reverse["forward"] = False
 
-            ctask = MolecularCollect({"xyzs":xyzsout,"check_symm":True,"fw_generators": ["optimize_firework",["vibrations_firework","IRC_firework","IRC_firework"]],
-                "fw_generator_dicts": [self["opt_obj_dict"],[self["vib_obj_dict"],irc_obj_dict_forward,irc_obj_dict_reverse]],
+                ctask = MolecularCollect({"xyzs":xyzsout,"check_symm":True,"fw_generators": ["optimize_firework",["vibrations_firework","IRC_firework","IRC_firework"]],
+                    "fw_generator_dicts": [self["opt_obj_dict"],[self["vib_obj_dict"],irc_obj_dict_forward,irc_obj_dict_reverse]],
                     "out_names": ["opt.xyz",["vib.json","irc_forward.traj","irc_reverse.traj"]],"future_check_symms": [True,False], "label": "TS"+str(index)+"_"+rxn_name})
-            cfw = Firework([ctask],name="TS"+str(index)+"_"+rxn_name+"_collect",spec={"_allow_fizzled_parents": True, "_priority": 5})
-            newwf = Workflow([cfw],name='rxn_'+str(index)+str(rxn_name))
-            return FWAction(detours=newwf) #using detour allows us to inherit children from the original collect to the subsequent collects
+                cfw = Firework([ctask],name="TS"+str(index)+"_"+rxn_name+"_collect",spec={"_allow_fizzled_parents": True, "_priority": 5})
+                newwf = Workflow([cfw],name='rxn_'+str(index)+str(rxn_name))
+                return FWAction(detours=newwf) #using detour allows us to inherit children from the original collect to the subsequent collects
+                
+            #if irc_mode == "skip":
+            else:
+                ctask = MolecularCollect({"xyzs":xyzsout,"check_symm":True,"fw_generators": ["optimize_firework",["vibrations_firework"]],
+                        "fw_generator_dicts": [self["opt_obj_dict"],[self["vib_obj_dict"]]],
+                        "out_names": ["opt.xyz",["vib.json"]],"future_check_symms": [True,False], "label": "TS"+str(index)+"_"+rxn_name})
+                cfw = Firework([ctask],name="TS"+str(index)+"_"+rxn_name+"_collect",spec={"_allow_fizzled_parents": True, "_priority": 5})
+                newwf = Workflow([cfw],name='rxn_'+str(index)+str(rxn_name))
+                return FWAction(detours=newwf) #using detour allows us to inherit children from the original collect to the subsequent collects
         else:
             return FWAction()
 


### PR DESCRIPTION
**Summary of modification** 

I have updated the way of running IRC by user's choice. 
In pynta class from main.py, the keyword `irc_mode` is added. User can add this keyword in Pynta input script.
If `irc_mode = "relaxed"`, irc is calculated with top half of the slab layers relaxed. `irc_obj_dict` updated accordingly.
If `irc_mode = "fixed"`, irc is calculated with all slab layers frozen. `irc_obj_dict` updated accordingly.
If `irc_mode`, is not "relaxed" nor "fixed", IRC is not calculated. It will call `MolecularTSEstimate_noIRC` in tasks.py 

------------------------------------------------------------------------------------------------------------------------
**Updated comments (04/15/2024)** 

- I added logging.info() in main.py and `setup_transition_states()`. This will generate pynta.log file and dump info, which file and module via `logging.info`, firetasks are running. It is only implemented in `setup_transition_states()` at the moment as a test. But will be expanded throughout pynta. print() statement is still there to parse the output to job output file generated by slurm.
- Made `IRC_obj_dict` as optional keyword for `MolecularTSEstimate `

------------------------------------------------------------------------------------------------------------------------
**Updated comments (04/19/2024)** 
  
- I created a copy of original pynta-irc branch for PR and future logger implementation. (will be deleted after PR is merged to the master)
- @mjohnson541 comments and modifications are added in this pull request. 
