### PR TITLE
Creating ASE database via running post processing notbook

### DIFF
--- a/IPython/Pynta Postprocessing.ipynb
+++ b/IPython/Pynta Postprocessing.ipynb
@@ -2,7 +2,18 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
+   "id": "a9583eb0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append(\"/Users/shikim/code/pynta_local/pynta/\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
    "id": "1b35dcf5",
    "metadata": {},
    "outputs": [],
@@ -22,17 +33,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "cb8417a3",
+   "execution_count": 3,
+   "id": "9d11ba4c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "path = \"/Users/mjohns9/Runs/pynta/Cu111_paper_rxns/Adsorbates/[Pt]\" #specify the path to the Pynta species directory"
+    "functional = 'BEEF-vdW'\n",
+    "pseudo = 'PAW'\n",
+    "metal = \"Pt\" #specify the metal\n",
+    "facet = \"fcc111\" #specify the facet\n",
+    "lattice_constant = 3.91 "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
+   "id": "cb8417a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path = \"/Users/shikim/production/pynta-production/for_shinae_hb/nh3-vdw-pt111-forMatt_hb_yesdiffusion_vib/Adsorbates/N[Pt]\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "77e8fdb6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "write_slab_db(path,functional,pseudo,lattice_constant,facet)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "id": "8414cbc8",
    "metadata": {},
    "outputs": [],
@@ -42,37 +77,100 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "e52fe41d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'0': -426.10433700005524, '1': -426.1046808013343, '3': -425.74558985664044}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "Es #energies for each unique successful species calculations"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "bab9cf27",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'0': [(201.94193643655098+0j),\n",
+       "  (327.325887994868+0j),\n",
+       "  (448.04500209129316+0j),\n",
+       "  (693.1445085208824+0j),\n",
+       "  (760.2628099610442+0j),\n",
+       "  (796.7789391711783+0j),\n",
+       "  (1512.1449293653186+0j),\n",
+       "  (3417.409723845569+0j),\n",
+       "  (3522.248035644658+0j)],\n",
+       " '1': [(211.8867947336871+0j),\n",
+       "  (326.892083497916+0j),\n",
+       "  (446.25050331692535+0j),\n",
+       "  (690.9968184328053+0j),\n",
+       "  (762.7389128602521+0j),\n",
+       "  (795.4641156526192+0j),\n",
+       "  (1513.3750294518761+0j),\n",
+       "  (3424.1433741129254+0j),\n",
+       "  (3528.5185907435452+0j)],\n",
+       " '3': [30.252499503843005j,\n",
+       "  (72.18077245886064+0j),\n",
+       "  (112.93205447505244+0j),\n",
+       "  (476.46572985938855+0j),\n",
+       "  (723.0357462933347+0j),\n",
+       "  (874.0123242915435+0j),\n",
+       "  (1495.741000991355+0j),\n",
+       "  (3379.0603726260483+0j),\n",
+       "  (3485.0127210691926+0j)]}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "freqs #frequencies for each unique successful species calculations"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "1db7c480",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'name': 'N[Pt]',\n",
+       " 'adjlist': '1 N u0 p1 c0 {2,S} {3,S} {4,S}\\n2 H u0 p0 c0 {1,S}\\n3 H u0 p0 c0 {1,S}\\n4 X u0 p0 c0 {1,S}\\n',\n",
+       " 'atom_to_molecule_atom_map': {'0': 0, '1': 1, '2': 2},\n",
+       " 'gratom_to_molecule_surface_atom_map': {'0': 0},\n",
+       " 'nslab': 36}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "json.load(open(os.path.join(path,\"info.json\"))) #General Species Information"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "068aeb86",
    "metadata": {},
    "outputs": [],
@@ -84,13 +182,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "08b656c3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<subprocess.Popen at 0x7fdfe1a720a0>"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "ind = 0 #display species geometry associated with specified index\n",
     "view(read(os.path.join(path,str(ind),str(ind)+\".xyz\")))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "a4e9b53b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "write_adsorbate_db(path,functional,pseudo,freqs)"
    ]
   },
   {
@@ -103,29 +222,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "02d9c6ab",
    "metadata": {},
    "outputs": [],
    "source": [
-    "path = \"/Users/mjohns9/Runs/pynta/Cu111_paper_rxns/TS1\" #specify the TS directory to analyze\n",
-    "metal = \"Cu\" #specify the metal\n",
+    "path = \"/Users/shikim/production/pynta-production/for_shinae_hb/nh3-vdw-pt111-forMatt_hb_yesdiffusion_vib/TS0\"#specify the TS directory to analyze\n",
+    "metal = \"Pt\" #specify the metal\n",
     "facet = \"fcc111\" #specify the facet"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "db46993c",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkIAAAGwCAYAAABFFQqPAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8pXeV/AAAACXBIWXMAAA9hAAAPYQGoP6dpAABOSUlEQVR4nO3dd1xV9f8H8Ne5g8sGEUWUIbgQt2DlyihH2nCU2nCbZVJqVtrWhqkNtYGm5VezpQ31V+Y3JfcqJ2lqIojiwC+CyuZe7j2f3x/IzSuIXLyXc7n39Xw87iPuuYdz35cL3ZefKQkhBIiIiIhckErpAoiIiIiUwiBERERELotBiIiIiFwWgxARERG5LAYhIiIiclkMQkREROSyGISIiIjIZWmULsCRybKM8+fPw8fHB5IkKV0OERERVYEQAnl5eWjYsCFUqsrbfBiEKnH+/HmEhoYqXQYRERFVw5kzZxASElLpOQxClfDx8QFQ+oP09fVVuBoiIiKqitzcXISGhpo/xyvDIFSJsu4wX19fBiEiIqJapirDWjhYmoiIiFwWg1AFEhISEB0djU6dOildChEREdmRxN3nbyw3Nxd+fn7Iyclh1xgREVEtYc3nN1uEiIiIyGUxCBEREZHLYhAiIiIil8UgRERERC6LQYiIiIhcFoMQERERuSwGoQpwHSEiIiLXwHWEKsF1hIiIiGofriNEREREVAXcdJWIiIhqlCwLFJaYUKA3orjEhPC6XorVwiBERERENpGVr8eetEv482Q2Ui8WQG80QW+UoS+RYTDJKDQYUaA3ocBgRNnAHG+dBn+/2UexmhmEiIiIqErOXCrE1uSLKDQYUWISKDHJMJoEsgtKA1DqxQKrrqeSALVKghACkiTZqerKMQgRERHRDV0pNGDtoQysOXgO+05fvun5UQ18cHtEANqE+MPLTQ2dVgWdRg2dRgV3rRpeOg28r97ctSrFAlAZBiEiIiIXV1xiQsLmFCT/L8/ieKHBhD9OZqPEVNqPpZKA2yPqItjPHRq1BI1aBa1KgqdOgw6h/rgtIgD+nm5KvIRqYxAiIiJyYUIIvPF/f+P7fWdveE50sC8GdmiEB9s3RJCvew1WZ38MQkRERC7s6z/T8f2+s1BJwPO9W8DfU2t+TCVJ6BDmj6gGzruWHoMQERGRi9p76hLe/PkIAGDqvVEY36OJwhXVPC6oWAFusUFERM4uI6cIT399AEZZ4P62wXjqzkilS1IEt9ioBLfYICIiZ1RcYsLQxX/grzNXENXAB6smdIGnm/N0Elnz+e08r5qIiMiJpWUV4FKBweKYEAIGowy9SYbBWHorW9vHYJJhNMkoufq1vuTq4oZGGf9cyMVfZ67Az0OLxcNjnSoEWct1XzkREVEt8fHGE5ibmGzTa6ok4JNHOyCsrqdNr1vbMAgRERE5sJ//Om8OQWEBnrh2/UEJgFatgpvm6k3973/L1vlxU6ugVUtw15YuaqjTqOGuVaFzk0DEhNdR5kU5EAYhIiIiB5V05gpe/OEvAMBTd0bi5X4tFa7I+XDWGBERkQM6f6UI45bvg94oo2fL+ph6b5TSJTklBiEiIiIHU2gw4okv9+Finh5RDXww/5EOUKuU3ZPLWbFrjIiIyEpCCMgCMMkCsii9VbQYjVEWKC4xodBgQpHBhKISE4pL/v267L5Jtvzmzccv4mhGLgK93fDFyFh46/hxbS/8yRIREVVRocGIuRuS8dUfp6E3ynZ9Lje1CouGxyCkjmvP6rI3BiEiIqIq2JWShZdWHUb6pUKrvk+tkuCpVcPdTQ0P7dWbW+nMLQ+tGu5aNTRqy5EqagkY0ikUMeEBtnwJVAEGISIiokrkFpdg1rpj+G7PGQBAQz93vD2gNWLC60CSJKhVElRS6Qal11NJEtw0HI7ryBiEiIjI6Z3OLsCB9MvQl8goLjGh2ChDXyIjX1+CK4UluFJUgpzCEuQUlaBEtuzyys43IKeoBAAw7I4wTLs3Cj7u2oqehmohBiEiInJaJSYZC7ek4pNNJ1Biqv7Wmo3remLOQ21xe2RdG1ZHjoBBiIiInNLR87l48ce/cOR8LgCgXYgf6vnooLu6wrK7Vg0vNzX8Pd3g76mFv4cb/Dy05bqy1CoJrRv5QqdRK/EyyM4YhCqQkJCAhIQEmEwmpUshIqIKCCFglEXpJqIlJsgC5mnsJlngx/1n8emmFBhlAX9PLd58sBUebNcQUgXjeMi1SUJUtPIBAUBubi78/PyQk5MDX19fpcshInJKhQYjxi7bh9SL+ShdTkeYg831hEDpbutGE+QqfHr1aRWEtwe0Rn0fd5vXTY7Lms9vtggREZGifvnrPHafzL6la0hXZ22pJQmSBAR66zCtbxQeaBvMViCqFIMQEREp6vt9ZwEAT/WIxID2jaC6GmYkoMIQo9OooNOW7qKuu7rTuorbT1A1MQgREZFiUjLzsf/0ZahVEsZ2jUB9X3ZhUc3iKk9ERKSYH/aXLlIY16IeQxApgkGIiIgUUWKS8dP+cwCAwbGhCldDropBiIiIFLH1+EVk5esR6O2Gu6PqK10OuSgGISIiUsT3+0q7xQZ2aAStmh9HpAz+5hERUY27mKfHpn8yAbBbjJTFIERERDVuzcFzMMoC7UP90TzIR+lyyIUxCBERUY0SQpi7xYawNYgUxiBEREQ16q+zOTiRmQ93rQr3twtWuhxycVxQkYiIqqXIYILpuv3ATLKAvsSE4hIZxUYTiktMKDFZnrNs1ykAQL/WwfB119ZUuUQVYhAiInIRR87nYHeq5Z5eZTlGQEAIQFxz7FomWcb/cvU4f6UI564U4dzlIuTpjbdUDwdJkyNgECIicgHbki9i7Jd7y7XO2IMkAe4aNdy1Krhr1dCqVbh+y7COYXVwe0SA3WshuhkGISIiJ5d05grGf70fJSaBjmH+CK/rZfG4dM0XEv7d8NTiHAmo56NDI39PNPR3R0gdD9T3dYfbdev/SBLgplZxx3eqNRiEiIicWEpmPkYv3YNCgwndmwViychOcNNwngxRGf41EBE5qYycIoxY8icuF5agXag/PhsWwxBEdB22CBER1VKyLKA3yigqKZ2dJYurA54FUGw0YcI3B3A+pxiR9bywdFQneOn4v3yi6/GvgoiohsmywLPfHcS+05cgBCALABBX/1uF7xcCxVenqN9MsJ87vhp7OwK83G6pZiJn5fRB6MyZMxg+fDgyMzOh0Wjw+uuvY/DgwUqXRUQubOuJi/j1cIZNr6lVS1BJpTdJAlSShNAAT3z8SHs08vew6XMROROnD0IajQbz589H+/btkZmZiY4dO6Jfv37w8vK6+TcTEdnB17tPAwCGxIZgZJfGkCBBpfp3xtb1KprBpdOo4eGmhodWDXetGmoVZ2kRVYfTB6Hg4GAEB5cu4V6/fn0EBATg0qVLDEJEpIgzlwqx6XjpruvjezRBZD1vhSsicm0OP31g27ZteOCBB9CwYUNIkoQ1a9aUO2fBggWIiIiAu7s7YmJisH379gqvtW/fPsiyjNBQrmZKRMr4bk86hAC6NQ1kCCJyAA4fhAoKCtCuXTt8+umnFT6+cuVKTJ48Ga+++ioOHjyI7t27o2/fvkhPT7c4Lzs7GyNGjMDixYtromwionL0RhNW7i3ddX3YHeEKV0NEACAJUdGuMo5JkiSsXr0aAwYMMB+7/fbb0bFjRyxcuNB8rGXLlhgwYABmzZoFANDr9ejVqxfGjRuH4cOH3/D6er0eer3efD83NxehoaHIycmBr6+v7V8QEbmU/0s6h0krktDA1x07psVBo3b4f4sS1Uq5ubnw8/Or0ud3rf4rNBgM2L9/P3r37m1xvHfv3ti1axcAQAiBUaNG4e677640BAHArFmz4OfnZ76xC42IbOmrq4OkH70tjCGIyEHU6r/ErKwsmEwmBAUFWRwPCgrChQsXAAA7d+7EypUrsWbNGrRv3x7t27fH4cOHK7zeyy+/jJycHPPtzJkzdn8NROQajmXkYt/py9CoJDxyG/+RReQonGLW2PWb+wkhzMe6desGWb75omMAoNPpoNPpbF4fEdHXf5S2BvVp1QBBvu4KV0NEZWp1i1BgYCDUarW59adMZmZmuVYiIiKl5BWXYPXBcwCAx+8IU7gaIrpWrW4RcnNzQ0xMDBITEzFw4EDz8cTERPTv37/a101ISEBCQgJMJpMtyiQiJyDLAnnFRpTIMmS5dDsMWQhUNNtEXLPnlywEfj2cgUKDCU3qeaFzZN0ar52Ibszhg1B+fj5SUlLM99PS0pCUlISAgACEhYVhypQpGD58OGJjY9G5c2csXrwY6enpGD9+fLWfMz4+HvHx8eZR50TkPFYfPIsdJ7IhhIAs/g001xMCyCkqQVa+HtkFBlwqMMBU1c3AbmD4HeHluvKJSFkOH4T27duHuLg48/0pU6YAAEaOHIlly5Zh6NChyM7OxltvvYWMjAy0bt0a69atQ3g41+ggIkuXCwx4/vu/qry56Y2oru7lpZKk8vtfXKWWJKik0jGMkgRE1vPGQzEht/bERGRztWodoZpmzToEROT4ytbxCanjgZGdG0MqCyooDTfX8/XQoq63DoHebgj01qGOpxvcNLV6aCWRS7Dm89vhW4SUwDFCRM5pa/JFAMB9bYIx7s5IhashIkfAf9pUID4+HkePHsXevXuVLoWIbESWBbZdDUI9WtRTuBoichQMQkTkEo6cz0VWvgFebmrEhgcoXQ4ROQgGISJyCVuTMwEAXZoGcpwPEZnx/wZE5BK2HC/tFruL3WJEdA0GoQokJCQgOjoanTp1UroUIrKBnMISHEi/DADo0ZxBiIj+xSBUAQ6WJnIuO1KyIAugaX1vhNTxVLocInIgDEJE5PS2HC8dH8TWICK6HoMQETk1IYR5/SCODyKi6zEIEZFTO5aRh8w8PTy0anRqzGnzRGSJQYiInNqWq9PmOzepC3etWuFqiMjRMAhVgLPGiJzHVk6bJ6JKMAhVgLPGiJxDXnEJ9p8unTZ/V/P6CldDRI6IQYiInNbOlGwYZYGIQC+E1eW0eSIqj7vPE1GtIssCecVG5BaXoMQkQxYCJhkwyQIlJhk5RSW4UlSCnEID1h7KAMBp80R0YwxCRKSIEpOM9377x9x1VRlZALnFJbhSWIIrhQbIwrrniotitxgRVYxBiIgU8d5v/+Dz7WnV/n6dRgU3tQoqlQS1SoJKkuCmluDroUUdTzf4e2rh76lF0/o+uLNZoA0rJyJnwiBERDXu10MZ5hD0ar+WCK/C+B0fdy3qeJWGHD8PLafCE5FNMAhVICEhAQkJCTCZTEqXQuR0UjLzMPXHvwAAT90ZiXF3RipcERG5MkkIYWVvu+vIzc2Fn58fcnJy4Ovrq3Q5RLVevt6IAQk7kZKZjzsiA/D12NuhUXPyKhHZljWf3/w/EBHVCCEEpv14CCmZ+Qjy1eGTRzsyBBGR4tg1RuSCyqaZ20pF7cp6owkX8/Slt3w9Dp3Jwa+HM6BRSVjweEfU89HZ7PmJiKqLQYjIhWTkFOGr3afx3Z50XC60XRCyxmv3tURMODc/JSLHwCBE5AIOpF/G0p2n8N/DGTBauwhPNWnVEup561DPR4d6Pu6o56NDp8Z1MLBDoxp5fiKiqmAQIqolTl7Mx6UCg8WxiiJNgd6ItKwCnLxYgJNZ+UjNLMCF3GLz47dFBGBM18bo2TKIY3SIyOUxCBHVAh9uOI5PNqVU+/vd1Co82L4hRnVpjNaN/GxYGRFR7cYgVAGuI0SOZOGWVHMICq/rCZUkWTwuXXe+m0aF8LqeiKznjchAL0TW80azIG/4umtrqGIiotqD6whVgusIkdK+2n0Kr//fEQDAS32jML5HE4UrIiJyfFxHiMgJ/LT/rDkEPXt3U4YgIiI7YNcYkcJKTDIuXx0EXdY8+8fJbLx4dRuKUV0aY0qv5gpVR0Tk3BiEiBRUZDCh59ytOHelqMLHB8eE4I37oyFJ148EIiIiW2AQIlLQ4XM55hCkVpWGHQmASpLwUEwjvDOgDVQqhiAiInthECJS0LGMXADAPVH1sWRUJ4WrISJyPRwsTaSgo+dLg1B0Q85KJCJSAoMQkYKOXSgNQi2DGYSIiJTAIESkEKNJxvELeQAYhIiIlMIgRKSQtKwC6I0yPN3UCA/wVLocIiKXxCBUgYSEBERHR6NTJw5eJfs5enWgdFQDH84MIyJSSJVmjQUEBFh1UUmScODAAYSHh1erKKXFx8cjPj7evEQ3kT0cy2C3GBGR0qoUhK5cuYL58+dXKRQIITBhwgRuWEp0E2UtQgxCRETKqfI6Qo888gjq169fpXOfffbZahdE5CrK1hDi1HkiIuVUKQjJsmzVRfPy8qpVDJGryMrX42KeHpJUOkaIiIiUUeXB0mvWrGF3F5GNlLUGNa7rBU83LvBORKSUKgehhx9+GI0aNcK0adPwzz//2LMmIqdnXlGa44OIiBRV5SCUnp6OZ599FqtXr0arVq3QrVs3LF26FAUFBfasj8gpHTMPlGa3GBGRkqochBo2bIhXX30VycnJ2LRpE5o0aYKJEyciODgYTzzxBHbv3m3POomcCqfOExE5hmotqNijRw98+eWXyMjIwNy5c3Hs2DF069YNrVq1snV9RE6nuMSElIv5ADhjjIhIabc0StPb2xtxcXE4deoU/vnnHyQnJ9uqLiKnlZKZD5Ms4O+pRQNfd6XLISJyadVqESosLMSXX36JHj16oHnz5li5ciWmTJmCU6dO2bg8IudjXkixgS8kiVtrEBEpyaoWoZ07d+I///kPfvjhBxiNRgwaNAi///474uLi7FUfkdMpmzHG8UFERMqrchBq3rw5UlNT0aFDB8yZMwePPfYY9+EiqgauKE1E5DiqHITuvfdejB07Fu3atbNnPUROTQjBqfNERA6kykHo448/Nn9tNBqxZcsWpKam4rHHHoOPjw/Onz8PX19feHt726VQImdw7koRcouN0KgkNK3PvxUiIqVZPWvs9OnTuPfee5Geng69Xo9evXrBx8cH7733HoqLi/HZZ5/Zo84alZCQgISEBG4pQjZXtn5Q0/re0GnUCldDRERWzxqbNGkSYmNjcfnyZXh4eJiPDxw4EBs3brRpcUqJj4/H0aNHsXfvXqVLISdjHh/EgdJERA7B6hahHTt2YOfOnXBzc7M4Hh4ejnPnztmsMCJnxBljRESOxeogJMtyhV1GZ8+ehY8PB39S7SaEuObrq/+9elxcPSZXcA4AFBqMSMsqQOrFfKRk5iP1YgH+l1sMkywgBGASAmcuFQLgjDEiIkdhdRDq1asX5s+fj8WLFwMAJElCfn4+pk+fjn79+tm8QKKakltcggc/2YFT2YV2fR4fnQatG3HpCSIiR2B1EJo3bx7i4uIQHR2N4uJiPPbYYzhx4gQCAwPx3Xff2aNGohqx79SlWw5Bjfw9EFnPC03qeaNpfW808veARi1BLUmQJAlqlYTGgZ7w89DaqGoiIroVVgehhg0bIikpCStWrMD+/fshyzLGjh2Lxx9/3GLwNFFtc/JiAQCgd3QQZj/UFgBQtgGGJAESJEiq0mOSJFk8BgBqlcSZYEREtUy1Nl318PDA6NGjMXr0aFvXQ6SY1Ks7wkc18EGAl9tNziYiImdQpenzP//8M0pKSqp80XXr1qGoqKjaRREpIfVqi1BkPS50SETkKqoUhAYOHIgrV65U+aKPPPIIMjIyqlsTkSJOXm0RasIgRETkMqrUNSaEwKhRo6DT6ap00eLi4lsqiqim5RSVICvfAACIqOelcDVERFRTqhSERo4cadVFH3/8cfj6cp0Uqj3KWoMa+LrDW1etoXNERFQLVen/+EuXLrV3HUSK+nd8EFuDiIhcidV7jRE5o7IWIQYhIiLXwiBEhH+nznOgNBGRa2EQIsK/iyly6jwRkWthECKXZzTJOH11a43IQHaNERG5EquDUFpamj3qIFLM2ctFMJhk6DQqNPLnNjFERK7E6iDUtGlTxMXF4euvv+Z6QeQUTmaVjg+KCPSCSiXd5GwiInImVgehv/76Cx06dMDzzz+PBg0a4KmnnsKePXvsURtRjSgbH9SkPscHERG5GquDUOvWrTF37lycO3cOS5cuxYULF9CtWze0atUKc+fOxcWLF+1RJ5HdmGeMcXwQEZHLqfZgaY1Gg4EDB+L777/HnDlzkJqaihdeeAEhISEYMWKEQ+01NnDgQNSpUwcPP/yw0qWQA+Jmq0RErqvaQWjfvn2YMGECgoODMXfuXLzwwgtITU3Fpk2bcO7cOfTv39+Wdd6SiRMnYvny5UqXQQ6Km60SEbkuqzdVmjt3LpYuXYrjx4+jX79+WL58Ofr16weVqjRTRUREYNGiRYiKirJ5sdUVFxeHLVu2KF0GOSButkpE5NqsbhFauHAhHnvsMaSnp2PNmjW4//77zSGoTFhYGJYsWWKTArdt24YHHngADRs2hCRJWLNmTblzFixYgIiICLi7uyMmJgbbt2+3yXOT8+Nmq0RErs3q//OfOHHipue4ublZvWP9jRQUFKBdu3YYPXo0HnrooXKPr1y5EpMnT8aCBQvQtWtXLFq0CH379sXRo0cRFhZm1XPp9Xro9Xrz/dzc3FuunxwbN1slInJtVgehQ4cOVXhckiS4u7sjLCwMOp3ulgsr07dvX/Tt2/eGj8+dOxdjx47FE088AQCYP38+1q9fj4ULF2LWrFlWPdesWbPw5ptv3lK9VLtws1UiItdmdRBq3749JOnGi85ptVoMHToUixYtgru7+y0VdzMGgwH79+/HSy+9ZHG8d+/e2LVrl9XXe/nllzFlyhTz/dzcXISGht5yneS4uNkqEZFrs3qM0OrVq9GsWTMsXrwYSUlJOHjwIBYvXowWLVrg22+/xZIlS7Bp0ya89tpr9qjXQlZWFkwmE4KCgiyOBwUF4cKFC+b7ffr0weDBg7Fu3TqEhIRg7969FV5Pp9PB19fX4kbOjZutEhG5NqtbhGbOnImPPvoIffr0MR9r27YtQkJC8Prrr2PPnj3w8vLC888/jw8++MCmxd7I9S1UQgiLY+vXr6+ROqh24WarRERkdYvQ4cOHER4eXu54eHg4Dh8+DKC0+6wmFlQMDAyEWq22aP0BgMzMzHKtRNZISEhAdHQ0OnXqdKslkgPjZqtERGR1EIqKisLs2bNhMBjMx0pKSjB79mzz2kHnzp27pSBSVW5uboiJiUFiYqLF8cTERHTp0qXa142Pj8fRo0dv2IVGzoGbrRIRkdVdYwkJCXjwwQcREhKCtm3bQpIkHDp0CCaTCWvXrgUAnDx5EhMmTLBJgfn5+UhJSTHfT0tLQ1JSEgICAhAWFoYpU6Zg+PDhiI2NRefOnbF48WKkp6dj/PjxNnl+cl7cbJWIiKwOQl26dMGpU6fw9ddfIzk5GUIIPPzww3jsscfg4+MDABg+fLjNCty3bx/i4uLM98tmdY0cORLLli3D0KFDkZ2djbfeegsZGRlo3bo11q1bV2H3HdG1uNkqERFJQghR1ZNLSkrQokULrF27FtHR0fasS1EJCQlISEiAyWRCcnIycnJyOIPMCQ1ZtBt70i5h/tD2GNChkdLlEBGRjeTm5sLPz69Kn99WtQhptVro9fpK1xFyBvHx8YiPjzf/IKl2k2WBc1eKcP5KEfKKjcjTlyC/2IjjF/IAcA0hIiJXZnXX2LPPPos5c+bgiy++gEbDvZnIfi4XGHC50HDT82QhUGSQUWAwotBgRIHehKx8PZL/l4d/LuQh+UIeCgymCr9XrZK42SoRkQuzOsn8+eef2LhxIzZs2IA2bdrAy8vyQ2TVqlU2K45c1+GzORi4YCeMcpV7biulVUsIqeMJX3cNfNy18HHXwFunQffm9bjZKhGRC7P6E8Df37/CzU+JbOmzbakwygI6jQpuGstVHq7vmJUkCZ5uani6qeGl08DTTQ1fdy2aBXmjRQNfRDXwQUSgF7Rqq1eLICIiJ2d1EFq6dKk96iAyO3elCL/9XbpI5uoJXRHdkAPViYjIPqr1T2Sj0Yjff/8dixYtQl5e6YDT8+fPIz8/36bFKYUrSytr+a5TMMkCnSPrMgQREZFdWTV9HgBOnz6Ne++9F+np6dDr9UhOTkZkZCQmT56M4uJifPbZZ/aqtcZZM/2ObKNAb0TnWRuRW2zEFyNi0TPa/iuUExGRc7Hm89vqFqFJkyYhNjYWly9fhofHv/szDRw4EBs3brS+WqJrrDpwFrnFRoTX9cTdUfWVLoeIiJyc1WOEduzYgZ07d8LNzc3ieHh4OM6dO2ezwsj1yLLA0p2nAACjuzTm/l9ERGR3VrcIybIMk6n8mixnz541b7FBVB1bkjNxMqsAPu4aDI4NVbocIiJyAVYHoV69emH+/Pnm+5IkIT8/H9OnT0e/fv1sWZtiOFhaGf/ZcQoA8EinUHhxbR8iIqoBVg+WPn/+POLi4qBWq3HixAnExsbixIkTCAwMxLZt21C/vvOM6+Bg6Zpz/EIe+szfBpUEbH0xDqEBnkqXREREtZTd9hoDgIYNGyIpKQnfffcdDhw4AFmWMXbsWDz++OMWg6eJrLF0ZxoA4N7WDRiCiIioxljdIuRK2CJkP9n5euw9dRn7Tl3C3lOXcPhcDmQB/Di+M2IbByhdHhER1WJ2bRECgOTkZGzZsgWZmZmQZdnisTfeeKM6lyQXEv/tAfx6KKPc8f7tGyImvI4CFRERkauyOgh9/vnnePrppxEYGIgGDRpAkv6d4ixJEoMQVcpoks0hqHmQN26LCECnxgGIbRyARv7sWiUioppldRB65513MHPmTEybNs0e9ZCTKyr5d+mFn5/pBnetWsFqiIjI1Vk9ff7y5csYPHiwPWpxGJw+bz9lQUglAToNd4MnIiJlWf1JNHjwYGzYsMEetTiM+Ph4HD16FHv37lW6FKdTbCgdU+ahVVt0qxIRESnB6q6xpk2b4vXXX8cff/yBNm3aQKvVWjw+ceJEmxVHzqewxAgA8HBjlxgRESnP6iC0ePFieHt7Y+vWrdi6davFY5IkMQhRpYoMpV1jDEJEROQIrA5CaWlp9qiDXIQ5CHGQNBEROQCOVqUaVTZYmkGIiIgcQZWDUHR0NC5dumS+/+STT+LixYvm+5mZmfD05NYIVDlzEGLXGBEROYAqB6F//vkHRqPRfH/FihXIy8sz3xdCoLi42LbVkdMpZNcYERE5kGp3jVW0RRmnQ9PNFF9tEfJ0q9buLkRERDbFMUIV4IKK9lM2WJorShMRkSOochCSJKlci4+ztgBxQUX7MXeNuTGDExGR8qrcPyGEwD333AONpvRbioqK8MADD8DNzQ0ALMYPEd0Iu8aIiMiRVPnTaPr06Rb3+/fvX+6chx566NYrIqdWNmuMXWNEROQIqh2EiKqDs8aIiMiRcKAG1agic9cYgxARESmPQYhqFLfYICIiR8IgRDXKPH2eLUJEROQAGISoRpm7xtgiREREDoBBiGqUuWuMLUJEROQArA5CEydOxMcff1zu+KefforJkyfboiZyYtx0lYiIHInVQeinn35C165dyx3v0qULfvzxR5sUpTRusWE/5iDErjEiInIAVgeh7Oxs+Pn5lTvu6+uLrKwsmxSlNG6xYT+cNUZERI7E6iDUtGlT/Pbbb+WO//e//0VkZKRNiiLnJITgOkJERORQrN7wacqUKXjmmWdw8eJF3H333QCAjRs34sMPP8T8+fNtXR85EYNJhkkWADh9noiIHIPVQWjMmDHQ6/WYOXMm3n77bQBA48aNsXDhQowYMcLmBZLzKDbI5q/ZNUZERI6gWluAP/3003j66adx8eJFeHh4wNvb29Z1kRMq6xbTqiVo1Vy5gYiIlFetIFSmXr16tqqDXEChwQiAO88TEZHjqFIQ6tixIzZu3Ig6deqgQ4cOkCTphuceOHDAZsWRc+HUeSIicjRVCkL9+/eHTqcDAAwYMMCe9ZATK+aMMSIicjBVCkLTp0+v8GsiaxSWbbjKFiEiInIQ1R4jZDAYkJmZCVmWLY6HhYXdclHknMoWU2SLEBEROQqrg1BycjLGjh2LXbt2WRwXQkCSJJhMJpsVR86F+4wREZGjsToIjR49GhqNBmvXrkVwcHClA6eJrsXtNYiIyNFYHYSSkpKwf/9+REVF2aMecmL/tgjd0qoNRERENmP1qnbR0dFOs7kq1axCc4sQF1MkIiLHYPUn0pw5czB16lRs2bIF2dnZyM3Ntbg5g4SEBERHR6NTp05Kl+JUirmOEBERORir+yh69uwJALjnnnssjjvTYOn4+HjEx8cjNzcXfn5+SpfjNMxjhNg1RkREDsLqT6TNmzfbow5yAYVsESIiIgdjdRDq0aOHPeogF1BsbhHiGCEiInIM1eqjuHLlCpYsWYJjx45BkiRER0djzJgx7EaiSnHWGBERORqr/2m+b98+NGnSBPPmzcOlS5eQlZWFuXPnokmTJtxwlSpVyHWEiIjIwVj9T/PnnnsODz74ID7//HNoNKXfbjQa8cQTT2Dy5MnYtm2bzYsk51DETVeJiMjBWB2E9u3bZxGCAECj0WDq1KmIjY21aXHkXLiyNBERORqru8Z8fX2Rnp5e7viZM2fg4+Njk6LIOZW1CHH3eSIichRWtwgNHToUY8eOxQcffIAuXbpAkiTs2LEDL774Ih599FF71Oh0hBAoMhYpXUaNKywpBCQDVGpD6ddEREQAPDQeiu1danUQ+uCDDyBJEkaMGAGj0QgA0Gq1ePrppzF79mybF+iMioxFuP3b25Uuo+Y1AHwaAE9sVboQIiJyJH8+9ic8tZ6KPLfVQcjNzQ0fffQRZs2ahdTUVAgh0LRpU3h6KvMCiIiIiKpLEkIIpYtwVGVbbOTk5MDX19dm13XFrjEhBFpN3wAA2D4tDnW93BSuiIiIHIWtu8as+fy2ukWouLgYn3zyCTZv3ozMzEzIsmzxONcSujlJkhRrAlRKkcEEiNLwE+DhDU8tF1UkIiLlWf1pNGbMGCQmJuLhhx/GbbfdptjgJqpdymaMAZw+T0REjsPqIPTrr79i3bp16Nq1qz3qISdVaCgdWK/TqKBSMTwTEZFjsHodoUaNGnG9ILJasXmfMbYGERGR47A6CH344YeYNm0aTp8+bY96yEkVGUrHknmyW4yIiByI1V1jsbGxKC4uRmRkJDw9PaHVai0ev3Tpks2KI+dR1jXmzhYhIiJyIFYHoUcffRTnzp3Du+++i6CgIA6WpiopGyzNgdJERORIrA5Cu3btwu7du9GuXTt71ENOqpg7zxMRkQOyeoxQVFQUiopqz2KAa9euRYsWLdCsWTN88cUXSpfjsgoN3HCViIgcj9VBaPbs2Xj++eexZcsWZGdnIzc31+LmSIxGI6ZMmYJNmzbhwIEDmDNnDscwKYRdY0RE5Iis7hq79957AQD33HOPxXEhBCRJgslkqujbFLFnzx60atUKjRo1AgD069cP69evx6OPPqpwZa6nyMCuMSIicjxWB6HNmzfbo44Kbdu2De+//z7279+PjIwMrF69GgMGDLA4Z8GCBXj//feRkZGBVq1aYf78+ejevTsA4Pz58+YQBAAhISE4d+5cjdVP/yoLQlxHiIiIHIlVQaikpAQzZszAokWL0Lx5c3vVZFZQUIB27dph9OjReOihh8o9vnLlSkyePBkLFixA165dsWjRIvTt2xdHjx5FWFgYKtpPtrJZbnq9Hnq93nzf0br6arN/u8a4xxgRETkOq8YIabVa/P333zU2Zb5v37545513MGjQoAofnzt3LsaOHYsnnngCLVu2xPz58xEaGoqFCxcCKF0F+9oWoLNnzyI4OPiGzzdr1iz4+fmZb6GhobZ9QS6s0NwiZPWwNCIiIrux+lNpxIgRWLJkiT1qsYrBYMD+/fvRu3dvi+O9e/fGrl27AAC33XYb/v77b5w7dw55eXlYt24d+vTpc8Nrvvzyy8jJyTHfzpw5Y9fX4EqKOViaiIgckNX9FAaDAV988QUSExMRGxsLLy8vi8fnzp1rs+Iqk5WVBZPJhKCgIIvjQUFBuHDhAgBAo9Hgww8/RFxcHGRZxtSpU1G3bt0bXlOn00Gn09m1bldl7hpzY9cYERE5Dqs/lf7++2907NgRAJCcnGzxmBKrTF//nGWz18o8+OCDePDBB2u6LLqOuWuMLUJERORAHHrWWGUCAwOhVqvNrT9lMjMzy7USWSshIQEJCQkOtRRAbffv7vMcI0RERI6j1n4qubm5ISYmBomJiRbHExMT0aVLl1u6dnx8PI4ePYq9e/fe0nXoX/+2CLFrjIiIHEe1PpX27t2LH374Aenp6TAYDBaPrVq1yiaFAUB+fj5SUlLM99PS0pCUlISAgACEhYVhypQpGD58OGJjY9G5c2csXrwY6enpGD9+vM1qINvgOkJEROSIrA5CK1aswIgRI9C7d28kJiaid+/eOHHiBC5cuICBAwfatLh9+/YhLi7OfH/KlCkAgJEjR2LZsmUYOnQosrOz8dZbbyEjIwOtW7fGunXrEB4ebtM66NZx1hgRETkiq4PQu+++i3nz5iE+Ph4+Pj746KOPEBERgaeeeqrSNXqq46677qpwUcRrTZgwARMmTLDp85LtFXKLDSIickBWjxFKTU3FfffdB6B0unlBQQEkScJzzz2HxYsX27xAJSQkJCA6OhqdOnVSuhSnUTZ9nrvPExGRI7E6CAUEBCAvLw9A6crNf//9NwDgypUrKCwstG11CuFgadsrC0JsESIiIkdidddY9+7dkZiYiDZt2mDIkCGYNGkSNm3ahMTExHI70hMBgEkWMBhlABwjREREjsXqIPTpp5+iuLgYQOmWFFqtFjt27MCgQYPw+uuv27xAqv3KWoMAzhojIiLHYnUQCggIMH+tUqkwdepUTJ061aZFkXMpmzovSYBOU2uXriIiIidU5SCUm5tbpfN8fX2rXYyj4MrStlV0zfYaSmzDQkREdCNVDkL+/v6VfoiV7fHlDOEhPj4e8fHxyM3NhZ+fn9Ll1HpFXEOIiIgcVJWD0LV7jAkh0K9fP3zxxRdo1KiRXQoj51FoMALg+CAiInI8VQ5CPXr0sLivVqtxxx13IDIy0uZFkXNhixARETkqjlwlu/t353kGISIiciwMQmR3hQa2CBERkWO6pSDkrDOAuMWGbXHneSIiclRVHiM0aNAgi/vFxcUYP348vLy8LI6vWrXKNpUpiLPGbKuY22sQEZGDqnIQuj4QDBs2zObFkHMq6xrjhqtERORoqhyEli5das86yIlx1hgRETkqDpYmuysbI8SuMSIicjQMQmR3bBEiIiJHxSBEdlfWIuTOFiEiInIwDEIV4PR52yosmzXGFiEiInIwDEIViI+Px9GjR7F3716lS3EKxVxHiIiIHBSDENld2RghTp8nIiJHwyBEdldonjVW5dUaiIiIagSDENldMWeNERGRg2IQIrsr5BghIiJyUAxCZHdcR4iIiBwVgxDZHWeNERGRo2IQqgDXEbIdIcS/6wgxCBERkYNhEKoA1xGynRKTgEkWADh9noiIHA+DENlV2fgggGOEiIjI8TAIkV2V7TOmUUlw0/DXjYiIHAs/mciuOGOMiIgcGYMQ2VURZ4wREZEDYxAiuyoqMQJgECIiIsfEIER2VWSQAbBrjIiIHBODENlVoYEtQkRE5LgYhMiuOFiaiIgcGYMQ2RV3niciIkfGIFQBbrFhO9x5noiIHBmDUAW4xYbtsGuMiIgcGYMQ2RV3niciIkfGIER2xa4xIiJyZAxCZFfsGiMiIkfGIER2VbbFhidbhIiIyAExCJFdsUWIiIgcGYMQ2VVZEHJnECIiIgfEIER2VWjuGtMoXAkREVF5DEJkV+aVpd34q0ZERI6Hn05kN0aTjIt5egDsGiMiIsfEIER2s3z3aWTkFMPXXYNWDf2ULoeIiKgcBiGyi//lFmNuYjIAYFrfKPh5aBWuiIiIqDwGIbKLt9YeRb7eiPah/ni0U5jS5RAREVWIQYhsblvyRfx6KAMqCXhnQGuoVJLSJREREVWIQagCCQkJiI6ORqdOnZQupdYpLjHhjf/7GwAwsktjtG7EsUFEROS4JCGEULoIR5Wbmws/Pz/k5OTA19dX6XJqhXmJyfho4wkE+erw+5Qe8HHn2CAiIqpZ1nx+s0WIbCYtqwALt6QCAF6/P5ohiIiIHB6DENnMnP/+A4NJRvdmgbivTbDS5RAREd0UgxDZRFpWAdYfvQAAeOP+aEgSB0gTEZHjYxAim/jPjjQIAcS1qIdmQT5Kl0NERFQlDEJ0yy4XGPDD/jMAgHHdIxWuhoiIqOoYhOiWfbsnHcUlMqKDfdG5SV2lyyEiIqoyBiG6JXqjCct2nQIAjLszgmODiIioVtEoXYBLEgIoKVS6Cpv49cBZ5OfloLGPO+5r4QcYCpQuiYiIahutJ6DQP6QZhJRQUgi821DpKmxiEIBB7gBKALyncDFERFQ7vXIecPNS5KnZNUZEREQuiy1CStB6lqbfWu6JL/diZ2o2ht0ejlfva6l0OUREVFtpPRV7agYhJUiSYk2AtnL8Qh5+Ty2ASnLHiB7RgJtyv8RERETVxa4xsppJFpj+c+kO831aNUBoAEMQERHVTgxCZLWPNp7AHycvwdNNjRf7tFC6HCIiompjECKr7ErJwiebTgAA3h3YBpH1vBWuiIiIqPoYhKjKLubpMWllEoQAhsaGYkCHRkqXREREdEsYhKhKTLLAcyuTcDFPjxZBPpjxYCulSyIiIrplDEJUJQs2p2BHShY8tGokPN4BHm5qpUsiIiK6ZZw+78JkWeC99cdx5HwOTLKASRaQRel/9UYZRQYTCg0mFJWYkFNUAgB4e0BrNK3vo3DlREREtuESQWjgwIHYsmUL7rnnHvz4449Kl+MwvvnzND7bmlrl80d0DsfDMSF2rIiIiKhmuUQQmjhxIsaMGYMvv/xS6VIcxplLhZj1338AAGO7RaBtiB/UKglqSYJKJUGnUcHTTQMPrRoebmr4umtQ39dd4aqJiIhsyyWCUFxcHLZs2aJ0GQ5DCIFpPx1CocGE2xoH4NV+LaFSKbPrLxERkZIUHyy9bds2PPDAA2jYsCEkScKaNWvKnbNgwQJERETA3d0dMTEx2L59e80X6kS+3ZOOXanZcNeq8N7DbRmCiIjIZSkehAoKCtCuXTt8+umnFT6+cuVKTJ48Ga+++ioOHjyI7t27o2/fvkhPTzefExMTg9atW5e7nT9f+zc2tbWzlwvx7q/HAAAv9olC48DavecZERHRrVC8a6xv377o27fvDR+fO3cuxo4diyeeeAIAMH/+fKxfvx4LFy7ErFmzAAD79++3SS16vR56vd58Pzc31ybXdRRCCLy86jAKDCbEhtfBqC6NlS6JiIhIUYoHocoYDAbs378fL730ksXx3r17Y9euXTZ/vlmzZuHNN9+0+XWVcOZSIZLOXIFRlmGSS6fKJ/8vD9tPZEGnKe0SU7NLjIiIXJxDB6GsrCyYTCYEBQVZHA8KCsKFCxeqfJ0+ffrgwIEDKCgoQEhICFavXo1OnTqVO+/ll1/GlClTzPdzc3MRGhpa/RdQw0yywLbki/jqj9PYfDwTQlR83gu9W3CPMCIiIjh4ECojSZYtF0KIcscqs379+iqdp9PpoNPprKpNCScv5uNyoQH6Ehl6kwx9iYyTWfn4bk86zlwqMp/XLtQfvu4ai2nxTep5Y0y3CAWrJyIichwOHYQCAwOhVqvLtf5kZmaWayVyFWsOnsPklUk3fNzPQ4vBMSF4/I5wRHAgNBERUaUcOgi5ubkhJiYGiYmJGDhwoPl4YmIi+vfvb7fnTUhIQEJCAkwmk92eo7p++7s0FAZ6uyHAyw1uGhV0GjV83DW4r00wHmjXEO5a7gNGRERUFYoHofz8fKSkpJjvp6WlISkpCQEBAQgLC8OUKVMwfPhwxMbGonPnzli8eDHS09Mxfvx4u9UUHx+P+Ph45Obmws/Pz27PYy1ZFvgzLRsAsGh4LGLC6yhcERERUe2meBDat28f4uLizPfLBiuPHDkSy5Ytw9ChQ5GdnY233noLGRkZaN26NdatW4fw8HClSlZMcmYeLheWwEOrRtsQxwloREREtZXiQeiuu+6CuNH0pqsmTJiACRMm1FBFjuuP1NLWoNjGdaBVK74WJhERUa3HT9MKJCQkIDo6usIp9kr64+QlAMAdkXUVroSIiMg5MAhVID4+HkePHsXevXuVLsXs2vFBDEJERES2wSBUS3B8EBERke0xCNUSf17tFuP4ICIiItvhJ2ot8cdJdosRERHZGoNQBRxtsHTp+KCygdIBCldDRETkPBiEKuBog6VPZObjUoEBHlo12jTyV7ocIiIip8EgVAuUdYvFNq4DNw3fMiIiIlvhp2otwPFBRERE9sEg5OCE4PggIiIie2EQcnAcH0RERGQ/DEIVcKRZY2XdYjHhHB9ERERka/xkrYAjzRr7d3wQu8WIiIhsjUHIgQkhuNEqERGRHTEIOSghBH77+wIuFRjgrlWhbYi/0iURERE5HY3SBVB5u1OzMS8xGXtOlbYG3dW8PscHERER2QGDkAJkWSAzT4/iEhOKjSboS2QUl5hwubAEy3efwq7U0nFBbhoVHr89DJPuaaZwxURERM6JQUgBRSUm3DFr4w0f16olPNIpDPFxTdHAz70GKyMiInItDEIVSEhIQEJCAkwmk12u765VQ62S4K5RwV2rhrtWDZ1WBXeNGh3D/fH0XU3RyN/DLs9NRERE/5KEEELpIhxVbm4u/Pz8kJOTA19fX6XLISIioiqw5vObI3CJiIjIZTEIERERkctiECIiIiKXxSBERERELotBiIiIiFwWgxARERG5LAYhIiIiclkMQhVISEhAdHQ0OnXqpHQpREREZEdcULESXFCRiIio9uGCikRERERVwCBERERELotBiIiIiFwWgxARERG5LAYhIiIiclkapQtwZGUT6nJzcxWuhIiIiKqq7HO7KhPjGYQqkZeXBwAIDQ1VuBIiIiKyVl5eHvz8/Co9h+sIVUKWZZw/fx4+Pj6QJMmm187NzUVoaCjOnDnDNYoUwvdAeXwPlMf3QHl8D2xPCIG8vDw0bNgQKlXlo4DYIlQJlUqFkJAQuz6Hr68vf/EVxvdAeXwPlMf3QHl8D2zrZi1BZThYmoiIiFwWgxARERG5LAYhheh0OkyfPh06nU7pUlwW3wPl8T1QHt8D5fE9UBYHSxMREZHLYosQERERuSwGISIiInJZDEJERETkshiEiIiIyGUxCClgwYIFiIiIgLu7O2JiYrB9+3alS3Jas2bNQqdOneDj44P69etjwIABOH78uMU5QgjMmDEDDRs2hIeHB+666y4cOXJEoYqd36xZsyBJEiZPnmw+xvfA/s6dO4dhw4ahbt268PT0RPv27bF//37z43wP7MtoNOK1115DREQEPDw8EBkZibfeeguyLJvP4XugEEE1asWKFUKr1YrPP/9cHD16VEyaNEl4eXmJ06dPK12aU+rTp49YunSp+Pvvv0VSUpK47777RFhYmMjPzzefM3v2bOHj4yN++ukncfjwYTF06FARHBwscnNzFazcOe3Zs0c0btxYtG3bVkyaNMl8nO+BfV26dEmEh4eLUaNGiT///FOkpaWJ33//XaSkpJjP4XtgX++8846oW7euWLt2rUhLSxM//PCD8Pb2FvPnzzefw/dAGQxCNey2224T48ePtzgWFRUlXnrpJYUqci2ZmZkCgNi6dasQQghZlkWDBg3E7NmzzecUFxcLPz8/8dlnnylVplPKy8sTzZo1E4mJiaJHjx7mIMT3wP6mTZsmunXrdsPH+R7Y33333SfGjBljcWzQoEFi2LBhQgi+B0pi11gNMhgM2L9/P3r37m1xvHfv3ti1a5dCVbmWnJwcAEBAQAAAIC0tDRcuXLB4T3Q6HXr06MH3xMbi4+Nx3333oWfPnhbH+R7Y388//4zY2FgMHjwY9evXR4cOHfD555+bH+d7YH/dunXDxo0bkZycDAD466+/sGPHDvTr1w8A3wMlcdPVGpSVlQWTyYSgoCCL40FBQbhw4YJCVbkOIQSmTJmCbt26oXXr1gBg/rlX9J6cPn26xmt0VitWrMCBAwewd+/eco/xPbC/kydPYuHChZgyZQpeeeUV7NmzBxMnToROp8OIESP4HtSAadOmIScnB1FRUVCr1TCZTJg5cyYeffRRAPw7UBKDkAIkSbK4L4Qod4xs75lnnsGhQ4ewY8eOco/xPbGfM2fOYNKkSdiwYQPc3d1veB7fA/uRZRmxsbF49913AQAdOnTAkSNHsHDhQowYMcJ8Ht8D+1m5ciW+/vprfPvtt2jVqhWSkpIwefJkNGzYECNHjjSfx/eg5rFrrAYFBgZCrVaXa/3JzMws968Asq1nn30WP//8MzZv3oyQkBDz8QYNGgAA3xM72r9/PzIzMxETEwONRgONRoOtW7fi448/hkajMf+c+R7YT3BwMKKjoy2OtWzZEunp6QD4d1ATXnzxRbz00kt45JFH0KZNGwwfPhzPPfccZs2aBYDvgZIYhGqQm5sbYmJikJiYaHE8MTERXbp0Uagq5yaEwDPPPINVq1Zh06ZNiIiIsHg8IiICDRo0sHhPDAYDtm7dyvfERu655x4cPnwYSUlJ5ltsbCwef/xxJCUlITIyku+BnXXt2rXcshHJyckIDw8HwL+DmlBYWAiVyvIjV61Wm6fP8z1QkIIDtV1S2fT5JUuWiKNHj4rJkycLLy8vcerUKaVLc0pPP/208PPzE1u2bBEZGRnmW2Fhofmc2bNnCz8/P7Fq1Spx+PBh8eijj3LKqp1dO2tMCL4H9rZnzx6h0WjEzJkzxYkTJ8Q333wjPD09xddff20+h++BfY0cOVI0atTIPH1+1apVIjAwUEydOtV8Dt8DZTAIKSAhIUGEh4cLNzc30bFjR/NUbrI9ABXeli5daj5HlmUxffp00aBBA6HT6cSdd94pDh8+rFzRLuD6IMT3wP5++eUX0bp1a6HT6URUVJRYvHixxeN8D+wrNzdXTJo0SYSFhQl3d3cRGRkpXn31VaHX683n8D1QhiSEEEq2SBEREREphWOEiIiIyGUxCBEREZHLYhAiIiIil8UgRERERC6LQYiIiIhcFoMQERERuSwGISIiInJZDEJERETkshiEiFzQsmXL4O/vr3QZFZIkCWvWrFHkuS9cuIBevXrBy8vLYX8+tjJjxgy0b99e6TKIFMcgRE5PkqRKb6NGjQIAbN68GXFxcQgICICnpyeaNWuGkSNHwmg0Vnr9gwcPYujQoQgODoZOp0N4eDjuv/9+/PLLL3DUhduHDh2K5OTkW76OyWTCvHnz0LZtW7i7u8Pf3x99+/bFzp07bVBlzZs3bx4yMjKQlJR0w5+PswSIF154ARs3brT788yYMaPCv7uoqCi7PzdRVWiULoDI3jIyMsxfr1y5Em+88YbFTtweHh44cuQI+vbti4kTJ+KTTz6Bh4cHTpw4gR9//NG8O3RF/u///g9DhgxBz5498eWXX6JJkybIzs7GoUOH8Nprr6F79+4O2bLg4eEBDw+PW7qGEAKPPPIIfv/9d7z//vu45557kJubi4SEBNx111344YcfMGDAgAq/t6SkBFqt9pae/0YMBgPc3Nyq9b2pqamIiYlBs2bNbFxV1QkhYDKZoNHY93/P3t7e8Pb2tutzlGnVqhV+//13i2P2fn238ntALkbRnc6IatjSpUuFn59fuePz5s0TjRs3tupa+fn5om7dumLgwIE3PEeW5Rs+7+rVq8X1f4I///yz6Nixo9DpdCIiIkLMmDFDlJSUmB+fPn26CA0NFW5ubiI4OFg8++yz5scSEhJE06ZNhU6nE/Xr1xcPPfTQDeu6vp7p06eLdu3aieXLl4vw8HDh6+srhg4dWumu1ytWrBAAxM8//1zusUGDBom6deuK/Px8i+svWbJERERECEmShCzLIjk5WXTv3l3odDrRsmVLsWHDBgFArF692nyts2fPiiFDhgh/f38REBAgHnzwQZGWlmZ+fOTIkaJ///7i3XffFcHBwSI8PPyGNS9YsEBERkYKrVYrmjdvLpYvX25+LDw83GJj3pEjR1Z4jbLXcv3zv//++6JBgwYiICBATJgwQRgMBvM5xcXF4sUXXxQhISHCzc1NNG3aVHzxxRdCCCE2b94sAIjffvtNxMTECK1WKzZt2iRkWRZz5swRERERwt3dXbRt21b88MMP5msajUYxZswY0bhxY+Hu7i6aN28u5s+fb1Hr5s2bRadOnYSnp6fw8/MTXbp0EadOnar26zh//rzo16+fcHd3F40bNxbffPONCA8PF/Pmzbvhz/z656lIeHi4mDlzphg9erTw9vYWoaGhYtGiRRbnVPf3YOfOnaJdu3ZCp9OJmJgY89/dwYMHhSzLokmTJuL999+3eK7Dhw8LSZJESkpKpXWTc2CLEBGABg0aICMjA9u2bcOdd95Zpe/ZsGEDsrOzMXXq1BueI0lSlWtYv349hg0bho8//hjdu3dHamoqnnzySQDA9OnT8eOPP2LevHlYsWIFWrVqhQsXLuCvv/4CAOzbtw8TJ07EV199hS5duuDSpUvYvn17lZ8bKG0NWbNmDdauXYvLly9jyJAhmD17NmbOnFnh+d9++y2aN2+OBx54oNxjzz//PFatWoXExERzq1BKSgq+//57/PTTT1Cr1ZBlGYMGDUJgYCD++OMP5ObmYvLkyRbXKSwsRFxcHLp3745t27ZBo9HgnXfewb333otDhw6Z/8W/ceNG+Pr6IjEx8YbdkatXr8akSZMwf/589OzZE2vXrsXo0aMREhKCuLg47N27FyNGjICvry8++ugjq1rMNm/ejODgYGzevBkpKSkYOnQo2rdvj3HjxgEARowYgd27d+Pjjz9Gu3btkJaWhqysLItrTJ06FR988AEiIyPh7++P1157DatWrcLChQvRrFkzbNu2DcOGDUO9evXQo0cPyLKMkJAQfP/99wgMDMSuXbvw5JNPIjg4GEOGDIHRaMSAAQMwbtw4fPfddzAYDNizZ0+lv5NVeR1ZWVnYsmULtFotpkyZgszMzCr/nCrz4Ycf4u2338Yrr7yCH3/8EU8//TTuvPNOREVFVfv3IC8vDw888AD69euHb7/9FqdPn7b4HZMkCWPGjMHSpUvxwgsvmI//5z//Qffu3dGkSRObvDZycEonMaKadKMWIaPRKEaNGiUAiAYNGogBAwaITz75ROTk5NzwWrNnzxYAxKVLl8zH9uzZI7y8vMy3X3755YbPe32LUPfu3cW7775rcc5XX30lgoODhRBCfPjhh6J58+YW/0Iv89NPPwlfX99KW3CuVVGLkKenp8X3v/jii+L222+/4TWioqJE//79K3zs0qVLAoCYM2eO+fparVZkZmaaz1m/fr1Qq9XizJkz5mP//e9/LVqElixZIlq0aGFuWRNCCL1eLzw8PMT69euFEKUtAUFBQUKv11f6mrt06SLGjRtncWzw4MGiX79+5vv9+/e/YUtQmYpaUsLDw4XRaLS47tChQ4UQQhw/flwAEImJiRVer6xFaM2aNeZj+fn5wt3dXezatcvi3LFjx4pHH330hrVNmDDB3BKYnZ0tAIgtW7bY5HUcO3ZMABB79+41P37ixAkB4KYtQiqVyuLvwsvLS4wdO9Z8Tnh4uBg2bJj5vizLon79+mLhwoVCiOr/HixcuFDUrVtXFBUVmY99/vnn5hYhIUpbudRqtfjzzz+FEEIYDAZRr149sWzZshu+JnIuHCxNBECtVmPp0qU4e/Ys3nvvPTRs2BAzZ85Eq1atLMYY3Uzbtm2RlJSEpKQkFBQU3HSg9bX279+Pt956yzx2w9vbG+PGjUNGRgYKCwsxePBgFBUVITIyEuPGjcPq1avN1+/VqxfCw8MRGRmJ4cOH45tvvkFhYaFVP4PGjRvDx8fHfD84OPiW/7V/betDeHg46tWrZ75/7NgxhIWFISQkxHysc+fOFt+/f/9+pKSkwMfHx/wzCQgIQHFxMVJTU83ntWnT5qbjQY4dO4auXbtaHOvatSuOHTtWrdd2rVatWkGtVpvvX/uzS0pKglqtRo8ePSq9RmxsrPnro0ePori4GL169bL4fVi+fLnF6/7ss88QGxuLevXqwdvbG59//jnS09MBAAEBARg1ahT69OmDBx54AB999NFNf5crex3Hjx+HRqNBx44dzY83bdoUderUudmPBy1atDD/XZTdrm9pbNu2rflrSZLQoEED83NX9/fg+PHj5oH8ZW677TaL5w0ODsZ9992H//znPwCAtWvXori4GIMHD77p6yLnwK4xoms0atQIw4cPx/Dhw/HOO++gefPm+Oyzz/Dmm2+WO7dsQO3x48dxxx13AAB0Oh2aNm1a7lyVSlWuy6akpMTivizLePPNNzFo0KBy3+/u7o7Q0FAcP34ciYmJ+P333zFhwgS8//772Lp1K3x8fHDgwAFs2bIFGzZswBtvvIEZM2Zg7969VR6sff3gZUmSKh0o3rx5cxw9erTCx8rCxbWDjr28vCzOuf7nUfac15JlGTExMfjmm2/KnXttqLr+2jdy/fWFEFZ1X95IZT+7qnaxXfsayr73119/RaNGjSzO0+l0AIDvv/8ezz33HD788EN07twZPj4+eP/99/Hnn3+az126dCkmTpyI3377DStXrsRrr72GxMRE8++rNa+joversuPXcnNzq/DvoqrPXd3fg4re34rqfeKJJzB8+HDMmzcPS5cuxdChQ+Hp6Vn5iyKnwRYhohuoU6cOgoODUVBQUOHjvXv3RkBAAObMmXPTa9WrVw95eXkW10pKSrI4p2PHjjh+/DiaNm1a7qZSlf6penh44MEHH8THH3+MLVu2YPfu3Th8+DCA0lk4PXv2xHvvvYdDhw7h1KlT2LRpUzVf/c098sgjOHHiBH755Zdyj3344YeoW7cuevXqdcPvj46ORnp6Os6fP28+tnv3botzOnbsiBMnTqB+/frlfiZ+fn5W1duyZUvs2LHD4tiuXbvQsmVLq65jrTZt2kCWZWzdurXK3xMdHQ2dTof09PRyrzs0NBQAsH37dnTp0gUTJkxAhw4d0LRpU4vWkTIdOnTAyy+/jF27dqF169b49ttvq/U6oqKiYDQacfDgQfOxlJQUXLlypVrXs0Z1fw+ioqJw6NAh6PV687F9+/aVO69fv37w8vLCwoUL8d///hdjxoyxy+sgx8QgRARg0aJFePrpp7FhwwakpqbiyJEjmDZtGo4cOVLhYGCgdPrxF198gV9//RX33Xcf1q9fj5MnT+LQoUN47733AMDczXD77bfD09MTr7zyClJSUvDtt99i2bJlFtd74403sHz5csyYMQNHjhzBsWPHzP+KB0oXQVyyZAn+/vtvnDx5El999RU8PDwQHh6OtWvX4uOPP0ZSUhJOnz6N5cuXQ5ZltGjRwm4/s0ceeQQDBw7EyJEjsWTJEpw6dQqHDh3CU089hZ9//hlffPFFpS01PXv2RIsWLTBixAj89ddf2L59O1599VWLcx5//HEEBgaif//+2L59O9LS0rB161ZMmjQJZ8+etareF198EcuWLcNnn32GEydOYO7cuVi1apXFIFl7aNy4MUaOHIkxY8ZgzZo1SEtLw5YtW/D999/f8Ht8fHzwwgsv4LnnnsOXX36J1NRUHDx4EAkJCfjyyy8BlHZL7du3D+vXr0dycjJef/117N2713yNtLQ0vPzyy9i9ezdOnz6NDRs2IDk5udrBLyoqCj179sSTTz6JPXv24ODBg3jyySfh4eFx01Y1o9GICxcuWNz+97//Vfm5q/t78Nhjj0GWZTz55JM4duwY1q9fjw8++ACAZeugWq3GqFGj8PLLL6Np06blumjJuTEIEaF03EB+fj7Gjx+PVq1aoUePHvjjjz+wZs2aSsd2DBw4ELt27YKnpydGjBiBFi1a4O6778amTZuwYsUK3H///QBKx2t8/fXXWLduHdq0aYPvvvsOM2bMsLhWnz59sHbtWiQmJqJTp0644447MHfuXISHhwMA/P398fnnn6Nr165o27YtNm7ciF9++QV169aFv78/Vq1ahbvvvhstW7bEZ599hu+++w6tWrWy289MkiR8//33ePXVVzFv3jxERUWhe/fuOH36NDZv3nzDNYTKqFQqrF69Gnq9HrfddhueeOKJcuNGPD09sW3bNoSFhWHQoEFo2bIlxowZg6KiIvj6+lpV74ABA/DRRx/h/fffR6tWrbBo0SIsXboUd911l5Wv3HoLFy7Eww8/jAkTJiAqKgrjxo27YUtjmbfffhtvvPEGZs2ahZYtW6JPnz745ZdfEBERAQAYP348Bg0ahKFDh+L2229HdnY2JkyYYP5+T09P/PPPP3jooYfQvHlzPPnkk3jmmWfw1FNPVft1LF++HEFBQbjzzjsxcOBAjBs3Dj4+PhZjcCpy5MgRBAcHW9zKfq+rorq/B76+vvjll1+QlJSE9u3b49VXX8Ubb7wBAOVqHjt2LAwGA1uDXJAkqtLBS0REdJ2zZ88iNDQUv//+O+655x6ly6mSb775BqNHj0ZOTo7F+K2dO3firrvuwtmzZxEUFKRghVTTOFiaiIiqZNOmTcjPz0ebNm2QkZGBqVOnonHjxlVee0sJy5cvR2RkJBo1aoS//voL06ZNw5AhQ8whSK/X48yZM3j99dcxZMgQhiAXxK4xIiKqkpKSErzyyito1aoVBg4ciHr16pkXV3RUFy5cwLBhw9CyZUs899xzGDx4MBYvXmx+/LvvvkOLFi2Qk5NjHttHroVdY0REROSy2CJERERELotBiIiIiFwWgxARERG5LAYhIiIiclkMQkREROSyGISIiIjIZTEIERERkctiECIiIiKX9f9efl8fWGMpOAAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "plot_eharm(path,Eharmtol=3.0,Eharmfiltertol=30.0) #plot the harmonic energies of the transition state guesses and cutoffs "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "8f5c68a4",
    "metadata": {},
    "outputs": [],
@@ -135,30 +265,82 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "d916e140",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'66': -782.8996406454244, '62': -783.0919547639205, '84': -782.9653538080165}"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "Es #energies for each unique successful saddle point optimization"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "56273b21",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'66': array([  0.        +636.22534109j, 207.31346786  +0.j        ,\n",
+       "        239.28630439  +0.j        , 361.5459269   +0.j        ,\n",
+       "        366.22945112  +0.j        , 452.3258527   +0.j        ]),\n",
+       " '62': array([  0.        +533.25395524j, 233.47600812  +0.j        ,\n",
+       "        311.8400834   +0.j        , 433.6942544   +0.j        ,\n",
+       "        517.43504863  +0.j        , 547.86351313  +0.j        ]),\n",
+       " '84': array([  0.        +515.82921591j, 220.43032856  +0.j        ,\n",
+       "        292.49191149  +0.j        , 434.61524873  +0.j        ,\n",
+       "        515.69024417  +0.j        , 542.59617987  +0.j        ])}"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "freqs #frequencies for each unique successful saddle point optimization"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "6887dfc0",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'forward': True,\n",
+       " 'name': 'N2 + 2X => 2 NX',\n",
+       " 'reactants': '1 *1 N u0 p1 c0 {3,T}\\n2 *2 N u0 p1 c0 {4,T}\\n3 *3 X u0 p0 c0 {1,T}\\n4 *4 X u0 p0 c0 {2,T}\\n',\n",
+       " 'products': '1 *1 N u0 p1 c0 {2,T}\\n2 *2 N u0 p1 c0 {1,T}\\n3 *3 X u0 p0 c0\\n4 *4 X u0 p0 c0\\n',\n",
+       " 'species_names': ['N#[Pt]', 'N#[Pt]'],\n",
+       " 'nslab': 36,\n",
+       " 'mols': ['1 N u0 p1 c0 {2,T}\\n2 X u0 p0 c0 {1,T}\\n',\n",
+       "  '1 N u0 p1 c0 {2,T}\\n2 X u0 p0 c0 {1,T}\\n'],\n",
+       " 'ads_sizes': [1, 1],\n",
+       " 'template_mol_map': [{'2': 1, '0': 0}, {'1': 0, '3': 1}],\n",
+       " 'reverse_names': ['N#N'],\n",
+       " 'molecule_to_atom_maps': [{'0': 0}, {'0': 0}]}"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "info = json.load(open(os.path.join(path,\"info.json\"),'r')) #General Transition State Information\n",
     "info"
@@ -166,7 +348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "82aa4e01",
    "metadata": {},
    "outputs": [],
@@ -176,92 +358,214 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "9f26eae8",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['N#[Pt]', 'N#[Pt]']"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "info[\"species_names\"] #Reactants in forward direction"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "9ed8fc01",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'66': -782.8996406454244, '62': -783.0919547639205, '84': -782.9653538080165}"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "fdEs #forward barriers"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "id": "18895197",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{}"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "farrs #forward rate coefficients"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "id": "43df3d39",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['N#N']"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "info[\"reverse_names\"] #Reactants in the reverse direction"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "id": "13e60de4",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'66': 3.6880220452380854, '62': 3.495707926741943, '84': 3.622308882645939}"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "rdEs #reverse barriers\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "id": "137b55d7",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'66': SurfaceArrhenius(A=(1.44967e-46,'m^5/(molecules^2*s)'), n=1.96842, Ea=(350.734,'kJ/mol'), T0=(1,'K'), Tmin=(298,'K'), Tmax=(2500,'K'), comment=\"\"\"Fitted to 50 data points; dA = *|/ 1.06173, dn = +|- 0.00758407, dEa = +|- 0.0526812 kJ/mol\"\"\"),\n",
+       " '62': SurfaceArrhenius(A=(9.8604e-47,'m^5/(molecules^2*s)'), n=1.88326, Ea=(330.973,'kJ/mol'), T0=(1,'K'), Tmin=(298,'K'), Tmax=(2500,'K'), comment=\"\"\"Fitted to 50 data points; dA = *|/ 1.03836, dn = +|- 0.00476562, dEa = +|- 0.0331034 kJ/mol\"\"\"),\n",
+       " '84': SurfaceArrhenius(A=(1.06737e-46,'m^5/(molecules^2*s)'), n=1.88958, Ea=(343.323,'kJ/mol'), T0=(1,'K'), Tmin=(298,'K'), Tmax=(2500,'K'), comment=\"\"\"Fitted to 50 data points; dA = *|/ 1.0395, dn = +|- 0.00490539, dEa = +|- 0.0340743 kJ/mol\"\"\")}"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "rarrs #reverse rate coefficients\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "id": "66ec7253",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "-75943.42639498618"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "get_gibbs_energy_reaction(rthermos,pthermos,298.)/1000.0 #Gibbs free energy of reaction at 298 K in kJ/mol"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "06ac822b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "197.45916810492312"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "get_entropy_reaction(rthermos,pthermos,298.) #Entropy of reaciton at 298 K in J/(mol K)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "id": "f9c16e4e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "-75884.58356289091"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_enthalpy_reaction(rthermos,pthermos,298.)/1000.0 #Enthalpy of reaction at 298 K in kJ/mol"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "7505b3b4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "get_enthalpy_reaction(rthermos,pthermos,298.)/1000.0 #Enthalpy of reaction at 298 K in kJ/mol"
+    "rate_data = parse_all_surface_arrhenius(rarrs)\n",
+    "write_rate_db(path,rate_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "147dff2f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "write_ts_db(path,functional,pseudo,freqs)"
    ]
   },
   {
@@ -279,7 +583,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ind = \"13\" #specify the index of the transition state to examine\n",
+    "ind = \"66\" #specify the index of the transition state to examine\n",
     "tsdir = os.path.join(path,ind)"
    ]
   },
@@ -339,7 +643,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.8.15 ('pynta_env')",
    "language": "python",
    "name": "python3"
   },
@@ -354,6 +658,11 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.15"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "497a1e6422a73997474db2888616a4dca116f11d0562e5e867b2970fb18557fb"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
SQLite database for adsorbates, transition state and rate coefficients can be created via post processing notebook.

Adsorbates and slab geometries, energies, frequencies, DFT parameters will be added to adsorbate.db.
Transition state geometries, energies, frequencies, DFT parameters will be saved in TS_geometry.db
 Rate coefficients calculated via post processing will be saved in rate_coeff.db.

The database are created and edited only when the user uses post processing notebook, giving users options of creating databases for geometries of their own interest. (Pick and chose to save)

**pynta postprocessing.ipynb:**
A section for DFT functional, Pseudopotentials, lattice parameters added
write_adsorbate_db(), write_ts_db(), write_slab_db(), write_rate_db() added 

**postprocessing.py:**
write_adsorbate_db() : create and write adsorbate.db for unique adsorbates (ones that calculates frequencies)

write_slab_db(): update slab info to adsorbate database

write_ts_db() : create and write ts_geometry.db for unique transition states geometries

parse_all_surface_arrhenius(): iterate by indices {key} and parse surface arrhenius information for unique TS
 - input: "farrs" for forward rate, "rarrs"  reverse rate
 - return: rate_data 
 
parse_surface_arrhenius(): parse SurfaceArrhenius from molecule. Define the SurfaceArrhenius named tuple for the example and extract dA, dn, dEa from the comment from the output. 

write_rate_db(): create rate_coeff.db. Save prefector, n, Ea, dA, dn, dEa in a string form from rate_data 