### PR TITLE
Switch to Internal Site Detection

### DIFF
--- a/pynta/main.py
+++ b/pynta/main.py
@@ -43,7 +43,7 @@ class Pynta:
         lattice_opt_software_kwargs={'kpts': (25,25,25), 'ecutwfc': 70, 'degauss':0.02, 'mixing_mode': 'plain'},
         reset_launchpad=False,queue_adapter_path=None,num_jobs=25,max_num_hfsp_opts=None,#max_num_hfsp_opts is mostly for fast testing
         Eharmtol=3.0,Eharmfiltertol=30.0,Ntsmin=5,frozen_layers=2,fmaxopt=0.05,fmaxirc=0.1,fmaxopthard=0.05,c=None,
-        surrogate_metal=None):
+        surrogate_metal=None,sites=None,site_adjacency=None):
 
         self.surface_type = surface_type
         if launchpad_path:
@@ -130,6 +130,9 @@ class Pynta:
         self.fmaxirc = fmaxirc
         self.fmaxopthard = fmaxopthard
 
+        self.sites = sites
+        self.site_adjacency = site_adjacency
+
         logger.info('Pynta class is initiated')
 
     def generate_slab(self,skip_launch=False):
@@ -175,13 +178,18 @@ class Pynta:
 
     def analyze_slab(self):
         full_slab = self.slab
-        cas = SlabAdsorptionSites(full_slab, self.surface_type,allow_6fold=False,composition_effect=False,
-                        label_sites=True,
-                        surrogate_metal=self.surrogate_metal)
-
-        self.cas = cas
-
-        unique_site_lists,unique_site_pairs_lists,single_site_bond_params_lists,double_site_bond_params_lists = generate_unique_placements(full_slab,cas)
+        
+        if self.sites is None:
+            logging.info("Attempting to automatically detect sites based on metal and facet using ACAT")
+            cas = SlabAdsorptionSites(full_slab, self.surface_type,allow_6fold=False,composition_effect=False,
+                            label_sites=True,
+                            surrogate_metal=self.surrogate_metal)
+            self.sites = cas.get_sites()
+            self.site_adjacency = cas.get_neighbor_site_list()
+        else:
+            assert self.site_adjacency is not None 
+            
+        unique_site_lists,unique_site_pairs_lists,single_site_bond_params_lists,double_site_bond_params_lists = generate_unique_placements(full_slab,self.sites)
 
         self.single_site_bond_params_lists = single_site_bond_params_lists
         self.single_sites_lists = unique_site_lists
@@ -264,7 +272,6 @@ class Pynta:
         Generates initial guess geometries for adsorbates and gas phase species
         Generates maps connecting the molecule objects with these adsorbates
         """
-        cas = self.cas
         structures = dict()
         gratom_to_molecule_atom_maps = dict()
         gratom_to_molecule_surface_atom_maps = dict()
@@ -286,7 +293,7 @@ class Pynta:
                     if os.path.exists(os.path.join(self.path,"Adsorbates",sm)): #assume initial guesses already generated
                         structures[sm] = None
                     else:
-                        structs = generate_adsorbate_guesses(mol,ads,self.slab,cas,mol_to_atoms_map,self.metal,
+                        structs = generate_adsorbate_guesses(mol,ads,self.slab,mol_to_atoms_map,self.metal,
                                            self.single_site_bond_params_lists,self.single_sites_lists,
                                            self.double_site_bond_params_lists,self.double_sites_lists,
                                            self.Eharmtol,self.Eharmfiltertol,self.Ntsmin)
@@ -496,7 +503,8 @@ class Pynta:
             ts_path = os.path.join(self.path,"TS"+str(i))
             os.makedirs(ts_path)
             ts_task = MolecularTSEstimate({"rxn": rxn,"ts_path": ts_path,"slab_path": self.slab_path,"adsorbates_path": os.path.join(self.path,"Adsorbates"),
-                    "rxns_file": self.rxns_file,"path": self.path,"metal": self.metal,"facet": self.surface_type, "out_path": ts_path, "irc_mode": self.irc_mode,
+                    "rxns_file": self.rxns_file,"path": self.path,"metal": self.metal,"facet": self.surface_type, "sites": self.sites, "site_adjacency": {str(k):v for k,v in self.site_adjacency.items()},
+                    "out_path": ts_path, "irc_mode": self.irc_mode,
                     "spawn_jobs": True, "opt_obj_dict": opt_obj_dict, "vib_obj_dict": vib_obj_dict, "IRC_obj_dict": IRC_obj_dict,
                     "nprocs": 48, "name_to_adjlist_dict": self.name_to_adjlist_dict,
                     "gratom_to_molecule_atom_maps":{sm: {str(k):v for k,v in d.items()} for sm,d in self.gratom_to_molecule_atom_maps.items()},

--- a/pynta/mol.py
+++ b/pynta/mol.py
@@ -241,10 +241,10 @@ def add_adsorbate_to_site(atoms, adsorbate, surf_ind, site, height=None,
         height = site_heights[site['site']]
 
     # Make the correct position
-    normal = site['normal']
+    normal = np.array(site['normal'])
     if np.isnan(np.sum(normal)):
         normal = np.array([0., 0., 1.])
-    pos = site['position'] + normal * height
+    pos = np.array(site['position']) + normal * height
 
     # Convert the adsorbate to an Atoms object
     if isinstance(adsorbate, Atoms):

--- a/pynta/mol.py
+++ b/pynta/mol.py
@@ -13,7 +13,7 @@ from acat.utilities import (custom_warning,
                          get_rodrigues_rotation_matrix,
                          get_angle_between,
                          get_rejection_between)
-from pynta.utils import get_unique_sym_struct_index_clusters, get_unique_sym, get_unique_sym_structs, get_unique_sym_struct_indices, get_occupied_sites
+from pynta.utils import get_unique_sym_struct_index_clusters, get_unique_sym, get_unique_sym_structs, get_unique_sym_struct_indices, get_occupied_sites, sites_match
 from pynta.calculator import run_harmonically_forced_xtb
 from rdkit import Chem
 from copy import deepcopy

--- a/pynta/mol.py
+++ b/pynta/mol.py
@@ -438,7 +438,7 @@ def generate_unique_placements(slab,sites):
 
     return unique_site_lists,unique_site_pairs_lists,single_site_bond_params_lists,double_site_bond_params_lists
 
-def generate_unique_site_additions(geo,cas,nslab,site_bond_params_list=[],sites_list=[]):
+def generate_unique_site_additions(geo,sites,slab,nslab,site_bond_params_list=[],sites_list=[]):
     nads = len(geo) - nslab
     #label sites with unique noble gas atoms
     he = Atoms('He',positions=[[0, 0, 0],])
@@ -449,9 +449,8 @@ def generate_unique_site_additions(geo,cas,nslab,site_bond_params_list=[],sites_
     rn = Atoms('Rn',positions=[[0, 0, 0],])
     site_tags = [he,ne,ar,kr,xe,rn]
     tag = site_tags[nads]
-    adcov = SlabAdsorbateCoverage(geo,adsorption_sites=cas)
-    sites = adcov.get_sites()
-    unocc = [site for site in sites if site["occupied"] == False]
+    occ = get_occupied_sites(geo,sites,nslab)
+    unocc = [site for site in sites if not any(sites_match(site,osite,slab) for osite in occ)]
 
     site_bond_params_lists = [deepcopy(site_bond_params_list) for i in range(len(unocc))]
     sites_lists = [deepcopy(sites_list) for i in range(len(unocc))]

--- a/pynta/mol.py
+++ b/pynta/mol.py
@@ -69,7 +69,7 @@ def get_adsorbate(mol):
     mol_to_atoms_map = {key:desorbed_to_atoms_map[val] for key,val in mol_to_desorbed_map.items()}
     return atoms,mol_to_atoms_map
 
-def generate_adsorbate_guesses(mol,ads,full_slab,cas,mol_to_atoms_map,metal,
+def generate_adsorbate_guesses(mol,ads,full_slab,mol_to_atoms_map,metal,
                                single_site_bond_params_lists,single_sites_lists,double_site_bond_params_lists,double_sites_lists,
                                Eharmtol,Eharmfiltertol,Ntsmin):
     mol_surf_inds = [mol.atoms.index(a) for a in mol.get_adatoms()]

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -468,7 +468,7 @@ class MolecularVibrationsTask(VibrationTask):
 
 @explicit_serialize
 class MolecularTSEstimate(FiretaskBase):
-    required_params = ["rxn","ts_path","slab_path","adsorbates_path","rxns_file","path","metal","facet",
+    required_params = ["rxn","ts_path","slab_path","adsorbates_path","rxns_file","path","metal","facet","sites","site_adjacency",
                         "name_to_adjlist_dict", "gratom_to_molecule_atom_maps",
                         "gratom_to_molecule_surface_atom_maps","irc_mode",
                         "vib_obj_dict","opt_obj_dict","nslab","Eharmtol","Eharmfiltertol","Ntsmin","max_num_hfsp_opts","surrogate_metal"]
@@ -487,6 +487,12 @@ class MolecularTSEstimate(FiretaskBase):
         metal = self["metal"]
         facet = self["facet"]
         nslab = self["nslab"]
+        sites = self["sites"]
+        for s in sites:
+            s["position"] = np.array(s["position"])
+            s["normal"] = np.array(s["normal"])
+        
+        site_adjacency = {int(k):v for k,v in self["site_adjacency"].items()}
         Eharmtol = self["Eharmtol"]
         Eharmfiltertol = self["Eharmfiltertol"]
         Ntsmin = self["Ntsmin"]
@@ -495,10 +501,6 @@ class MolecularTSEstimate(FiretaskBase):
         surrogate_metal = self["surrogate_metal"]
         slab = read(slab_path)
         irc_mode = self["irc_mode"]
-
-        cas = SlabAdsorptionSites(slab,facet,allow_6fold=False,composition_effect=False,
-                            label_sites=True,
-                            surrogate_metal=surrogate_metal)
 
         adsorbates_path = self["adsorbates_path"]
 
@@ -520,7 +522,7 @@ class MolecularTSEstimate(FiretaskBase):
         reactant_mols = [mol_dict[name] for name in reactant_names]
         product_mols = [mol_dict[name] for name in product_names]
 
-        adsorbates = get_unique_optimized_adsorbates(rxn,adsorbates_path,mol_dict,cas,gratom_to_molecule_surface_atom_maps,nslab)
+        adsorbates = get_unique_optimized_adsorbates(rxn,adsorbates_path,mol_dict,gratom_to_molecule_surface_atom_maps,sites,nslab)
 
         forward,species_names = determine_TS_construction(reactant_names,
                     reactant_mols,product_names,product_mols)
@@ -565,7 +567,7 @@ class MolecularTSEstimate(FiretaskBase):
                         ase_to_mol_num[aind] = i
                         break
 
-        tsstructs = get_unique_TS_structs(adsorbates,species_names,slab,cas,nslab,num_surf_sites,mol_dict,
+        tsstructs = get_unique_TS_structs(adsorbates,species_names,slab,sites,site_adjacency,nslab,num_surf_sites,mol_dict,
                                  gratom_to_molecule_atom_maps,gratom_to_molecule_surface_atom_maps,
                                  facet,metal)
 
@@ -578,11 +580,11 @@ class MolecularTSEstimate(FiretaskBase):
                                             ordered_names=species_names,reverse_names=reverse_names,
                                             mol_dict=mol_dict,gratom_to_molecule_atom_maps=gratom_to_molecule_atom_maps,
                                             gratom_to_molecule_surface_atom_maps=gratom_to_molecule_surface_atom_maps,
-                                            nslab=nslab,facet=facet,metal=metal,cas=cas)
+                                            nslab=nslab,facet=facet,metal=metal,slab_sites=sites,site_adjacency=site_adjacency)
 
 
         out_tsstructs,new_atom_bond_potential_lists,new_site_bond_potential_lists,new_constraint_lists = get_surface_forming_bond_pairings(
-                            tsstructs_out,atom_bond_potential_lists,site_bond_potential_lists,constraint_lists,site_bond_dict_list,cas)
+                            tsstructs_out,slab,atom_bond_potential_lists,site_bond_potential_lists,constraint_lists,site_bond_dict_list,sites)
 
         print("number of TS guesses with empty sites:")
         print(len(out_tsstructs))

--- a/pynta/transitionstate.py
+++ b/pynta/transitionstate.py
@@ -1,23 +1,9 @@
 from molecule.molecule import Molecule, Bond
-from molecule.molecule.pathfinder import find_shortest_path
 import yaml
-from ase.io import read, write
+from ase.io import read
 import numpy as np
-from ase.data import covalent_radii
-from acat.adsorption_sites import SlabAdsorptionSites
-from acat.adsorbate_coverage import SlabAdsorbateCoverage
-from acat.settings import adsorbate_molecule
-from acat.utilities import (custom_warning,
-                         is_list_or_tuple,
-                         get_close_atoms,
-                         get_rodrigues_rotation_matrix,
-                         get_angle_between,
-                         get_rejection_between)
 import os
-from pynta.utils import get_unique_sym, get_unique_sym_structs
-from ase.visualize import view
-from ase.atoms import Atoms, Atom
-from ase.geometry import get_distances
+from pynta.utils import get_unique_sym, get_unique_sym_structs, sites_match
 import itertools
 from pynta.calculator import HarmonicallyForcedXTB
 from pynta.mol import *
@@ -25,7 +11,7 @@ from copy import deepcopy
 from pysidt import *
 import pynta.models
 
-def get_unique_optimized_adsorbates(rxn,adsorbates_path,mol_dict,cas,gratom_to_molecule_surface_atom_maps,nslab):
+def get_unique_optimized_adsorbates(rxn,adsorbates_path,mol_dict,gratom_to_molecule_surface_atom_maps,sites,nslab):
     """
     load the adsorbates associated with the reaction and find the unique optimized
     adsorbate structures for each species
@@ -45,9 +31,7 @@ def get_unique_optimized_adsorbates(rxn,adsorbates_path,mol_dict,cas,gratom_to_m
         adsorbates[name] = []
         for xyz in xyzs:
             geo = read(xyz)
-            adcov = SlabAdsorbateCoverage(geo,adsorption_sites=cas)
-            sites = adcov.get_sites()
-            occ = [site for site in sites if site["occupied"]]
+            occ = get_occupied_sites(geo,sites,nslab)
             required_surface_inds = set([ind+nslab for ind in ase_to_mol_surface_atom_map.keys()])
             found_surface_inds = set([site["bonding_index"] for site in occ])
             if len(occ) >= len(mol_dict[name].get_adatoms()) and required_surface_inds.issubset(found_surface_inds):
@@ -161,22 +145,20 @@ def determine_TS_construction(reactant_names,reactant_mols,product_names,product
     return forward,ordered_reacting_species
 
 
-def get_unique_TS_structs(adsorbates,species_names,slab,cas,nslab,num_surf_sites,mol_dict,
+def get_unique_TS_structs(adsorbates,species_names,slab,slab_sites,site_adjacency,nslab,num_surf_sites,mol_dict,
                           gratom_to_molecule_atom_maps,gratom_to_molecule_surface_atom_maps,
                           facet,metal,gas_height=5.0):
     """
     Generate unique initial structures for TS guess generation
     """
     tsstructs = []
-    slab_sites = cas.get_sites()
-    site_adjacency = cas.get_neighbor_site_list()
     ordered_adsorbates = [adsorbates[name] for name in species_names]
     for adss in itertools.product(*ordered_adsorbates):
         if num_surf_sites[0] > 0:
             adslab = adss[0].copy()
         else:
             adslab = slab.copy()
-            site = cas.get_sites()[0]
+            site = slab_sites[0]
             add_adsorbate_to_site(adslab,adsorbate=adss[0],surf_ind=0,site=site,height=gas_height)
         if len(adss) == 1:
             tsstructs.append(adslab)
@@ -190,10 +172,10 @@ def get_unique_TS_structs(adsorbates,species_names,slab,cas,nslab,num_surf_sites
                 sitetype1 = list(sites1.values())[0]
                 height1 = list(site_lengths1.values())[0]
                 surf_ind1 = list(gratom_to_molecule_surface_atom_maps[name].keys())[0]
-                adcov = SlabAdsorbateCoverage(adslab,adsorption_sites=cas)
-                for site in adcov.get_sites():
+                occ = get_occupied_sites(adslab,slab_sites,nslab)
+                for site in slab_sites:
                     adslab2 = adslab.copy()
-                    if site['occupied'] == False and site["site"] == sitetype1:
+                    if not any(sites_match(site,osite,slab) for osite in occ) and site["site"] == sitetype1:
                         add_adsorbate_to_site(adslab2,adsorbate=ad,surf_ind=surf_ind1,site=site,height=height1)
                         if len(adss) == 2:
                             tsstructs.append(adslab2)
@@ -207,43 +189,41 @@ def get_unique_TS_structs(adsorbates,species_names,slab,cas,nslab,num_surf_sites
                                 sitetype2 = list(sites2.values())[0]
                                 height2 = list(site_lengths2.values())[0]
                                 surf_ind2 = list(gratom_to_molecule_surface_atom_maps[name2].keys())[0]
-                                adcov2 = SlabAdsorbateCoverage(adslab2,adsorption_sites=cas)
+                                occ2 = get_occupied_sites(adslab2,slab_sites,nslab)
                                 for site2 in adcov2.get_sites():
                                     adslab3 = adslab2.copy()
-                                    if site2['occupied'] == False and site2["site"] == sitetype2:
+                                    if not any(sites_match(site2,osite,slab) for osite in occ2) and site2["site"] == sitetype2:
                                         add_adsorbate_to_site(adslab3,adsorbate=ad2,surf_ind=surf_ind2,site=site2,height=height2)
                                         if len(adss) == 3:
                                             tsstructs.append(adslab3)
                                         else:
                                             raise ValueError("Cannot handle more than three reactants")
                             else:
-                                adcovl2 = SlabAdsorbateCoverage(adslab2,adsorption_sites=cas)
-                                sites = adcovl2.get_sites()
+                                occl2 = get_occupied_sites(adslab2,slab_sites,nslab)
                                 c = 0
-                                site = sites[c]
-                                while site["occupied"] == True:
+                                sitel2 = slab_sites[c]
+                                while any(sites_match(sitel2,osite,slab) for osite in occl2): #while occupied
                                     c += 1
-                                    site = sites[c]
-                                add_adsorbate_to_site(adslab,adsorbate=adss[2],surf_ind=0,site=site,height=gas_height)
+                                    sitel2 = slab_sites[c]
+                                add_adsorbate_to_site(adslab,adsorbate=adss[2],surf_ind=0,site=sitel2,height=gas_height)
 
             elif num_surf_sites[1] == 0:
-                adcovl1 = SlabAdsorbateCoverage(adslab,adsorption_sites=cas)
-                sites = adcovl1.get_sites()
+                occl1 = get_occupied_sites(adslab,slab_sites,nslab)
                 c = 0
-                site = sites[c]
-                while site["occupied"] == True:
+                sitel1 = slab_sites[c]
+                while any(sites_match(sitel1,osite,slab) for osite in occl1): #while occupied
                     c += 1
-                    site = sites[c]
+                    sitel1 = slab_sites[c]
 
-                add_adsorbate_to_site(adslab,adsorbate=adss[1],surf_ind=0,site=site,height=gas_height)
+                add_adsorbate_to_site(adslab,adsorbate=adss[1],surf_ind=0,site=sitel1,height=gas_height)
                 if len(adss) == 2:
                     tsstructs.append(adslab)
                 else:
                     c = 0
-                    site2 = sites[c]
-                    while site2["occupied"] == True and site2 != site:
+                    site2 = slab_sites[c]
+                    while any(sites_match(site2,osite,slab) for osite in occl1) and site2 != sitel1:
                         c += 1
-                        site2 = sites[c]
+                        site2 = slab_sites[c]
                     add_adsorbate_to_site(adslab,adsorbate=adss[2],surf_ind=0,site=site2,height=gas_height)
                     if len(adss) == 3:
                         tsstructs.append(adslab)
@@ -256,7 +236,7 @@ def get_unique_TS_structs(adsorbates,species_names,slab,cas,nslab,num_surf_sites
 def generate_constraints_harmonic_parameters(tsstructs,adsorbates,slab,forward_template,
                                              reverse_template,template_name,template_reversed,
                                             ordered_names,reverse_names,mol_dict,gratom_to_molecule_atom_maps,
-                                            gratom_to_molecule_surface_atom_maps,nslab,facet,metal,cas):
+                                            gratom_to_molecule_surface_atom_maps,nslab,facet,metal,slab_sites,site_adjacency):
     """
     Generate constraints and harmonic parameters for the harmonically forced optimization
     """
@@ -265,8 +245,6 @@ def generate_constraints_harmonic_parameters(tsstructs,adsorbates,slab,forward_t
     site_bond_potential_lists = []
     site_bond_dict_list = []
     out_structs = []
-    slab_sites = cas.get_sites()
-    site_adjacency = cas.get_neighbor_site_list()
     
     nodes_file = os.path.join(os.path.split(pynta.models.__file__)[0],"TS_tree_nodes.json")
     nodes = read_nodes(nodes_file)
@@ -340,9 +318,8 @@ def generate_constraints_harmonic_parameters(tsstructs,adsorbates,slab,forward_t
         fixed_bond_pairs = []
         site_bond_dict = dict()
 
-        adcov = SlabAdsorbateCoverage(tsstruct,adsorption_sites=cas)
-        sites = adcov.get_sites()
-        occ = [site for site in sites if site["occupied"]]
+        occ = get_occupied_sites(tsstruct,slab_sites,nslab)
+        
         if len(occ) < len(forward_template.get_adatoms()): #if we don't identify as many occupied sites as we should skip this structure
             print("occupied not equal to forward_template")
             print("occ={0}".format(len(occ)))
@@ -352,7 +329,6 @@ def generate_constraints_harmonic_parameters(tsstructs,adsorbates,slab,forward_t
         occ_bd_lengths = {site["bonding_index"]:site['bond_length'] for site in occ}
         occ_site_types = {site["bonding_index"]:site['site'] for site in occ}
         occ_site_pos = {site["bonding_index"]:site['position'] for site in occ}
-        unocc = [site for site in sites if not site["occupied"]]
 
         for edge in forward_template.get_all_edges():
             ind1 = forward_template.atoms.index(edge.atom1)
@@ -397,7 +373,7 @@ def generate_constraints_harmonic_parameters(tsstructs,adsorbates,slab,forward_t
                     ind = ase_ind1
                 deq,k = estimate_deq_k(sidt,labels,dwell,forward_template,reverse_template,template_name,template_reversed,broken_bonds,formed_bonds,sitetype=sitetype)
                 if pos is not None:
-                    d = {"ind":ind,"site_pos":pos.tolist(),"k":k,"deq":deq}
+                    d = {"ind":ind,"site_pos":pos,"k":k,"deq":deq}
                     site_bond_potentials.append(d)
                 else:
                     d = {"ind1":ase_ind1,"ind2":ase_ind2,"k":k,"deq":deq}
@@ -412,7 +388,7 @@ def generate_constraints_harmonic_parameters(tsstructs,adsorbates,slab,forward_t
                     pos[2] += dwell #shift position up to atom position
                     ind = ase_ind2
                     deq,k = estimate_deq_k_fixed_surf_bond(labels,dwell,forward_template,reverse_template,template_name,template_reversed,broken_bonds,formed_bonds,sitetype=sitetype)
-                    d = {"ind":ind,"site_pos":pos.tolist(),"k":k,"deq":deq}
+                    d = {"ind":ind,"site_pos":pos,"k":k,"deq":deq}
                     site_bond_potentials.append(d)
                 else:
                     dwell = occ_bd_lengths[ase_ind1]
@@ -421,7 +397,7 @@ def generate_constraints_harmonic_parameters(tsstructs,adsorbates,slab,forward_t
                     pos[2] += dwell #shift position up to atom position
                     ind = ase_ind1
                     deq,k = estimate_deq_k_fixed_surf_bond(labels,dwell,forward_template,reverse_template,template_name,template_reversed,broken_bonds,formed_bonds,sitetype=sitetype)
-                    d = {"ind":ind,"site_pos":pos.tolist(),"k":k,"deq":deq}
+                    d = {"ind":ind,"site_pos":pos,"k":k,"deq":deq}
                     site_bond_potentials.append(d)
 
         for labels in formed_bonds: #bonds that form
@@ -481,7 +457,7 @@ def generate_constraints_harmonic_parameters(tsstructs,adsorbates,slab,forward_t
                             if reused_site_type == sitetype:
                                 pos = deepcopy(reused_site_pos)
                                 pos[2] += dwell
-                                d = {"ind":ase_ind2,"site_pos":pos.tolist(),"k":k,"deq":deq}
+                                d = {"ind":ase_ind2,"site_pos":pos,"k":k,"deq":deq}
                                 site_bond_potentials.append(d)
                                 if ase_ind2 in site_bond_dict.keys():
                                     del site_bond_dict[ase_ind2]
@@ -520,7 +496,7 @@ def generate_constraints_harmonic_parameters(tsstructs,adsorbates,slab,forward_t
                             if reused_site_type == sitetype:
                                 pos = deepcopy(reused_site_pos)
                                 pos[2] += dwell
-                                d = {"ind":ase_ind1,"site_pos":pos.tolist(),"k":k,"deq":deq}
+                                d = {"ind":ase_ind1,"site_pos":pos,"k":k,"deq":deq}
                                 site_bond_potentials.append(d)
                                 if ase_ind1 in site_bond_dict.keys():
                                     del site_bond_dict[ase_ind1]
@@ -583,15 +559,16 @@ def estimate_deq_k_fixed_surf_bond(labels,dwell,forward_template,reverse_templat
     """
     return 0.0,100.0
 
-def get_surface_forming_bond_pairings(tsstructs,atom_bond_potential_lists,
+def get_surface_forming_bond_pairings(tsstructs,slab,atom_bond_potential_lists,
                                       site_bond_potential_lists,constraints_list,site_bond_dict_list,
-                                      cas):
+                                      slab_sites):
     """
     Identify unique site targets for the harmonically forced optimization
     """
     if len(site_bond_dict_list[0]) == 0: #no site bonds formed
         return tsstructs,atom_bond_potential_lists,site_bond_potential_lists,constraints_list
 
+    nslab = len(slab)
     adslablen = len(tsstructs[0])
 
     #label sites with unique noble gas atoms
@@ -614,8 +591,8 @@ def get_surface_forming_bond_pairings(tsstructs,atom_bond_potential_lists,
     for i,tsstruct in enumerate(tsstructs):
         atom_bond_potential_list = atom_bond_potential_lists[i]
         constraints = constraints_list[i]
-        adcov = SlabAdsorbateCoverage(tsstruct,adsorption_sites=cas)
-        unocc = [site for site in adcov.get_sites() if site["occupied"] == False]
+        occ = get_occupied_sites(tsstruct,slab_sites,nslab)
+        unocc = [site for site in slab_sites if not any(sites_match(site,osite,slab) for osite in occ)]
         site_bond_dict = site_bond_dict_list[i]
         site_bond_potential_dict = sites_to_site_bond_potentials(unocc,site_bond_dict,atm_inds)
         geoms = []
@@ -634,7 +611,7 @@ def get_surface_forming_bond_pairings(tsstructs,atom_bond_potential_lists,
                     site = sites[j]
                     add_adsorbate_to_site(geo,adsorbate=tag,surf_ind=0,site=site,height=1.5)
                     params = bond_dict[site["site"]].copy()
-                    params["site_pos"] = site["position"].tolist()
+                    params["site_pos"] = site["position"]
                     params["site_pos"][2] += params["dwell"]
                     del params["dwell"]
                     params["ind"] = atm_ind
@@ -673,7 +650,7 @@ def sites_to_site_bond_potentials(sites,site_bond_dicts,atm_inds):
             bond_dict = site_bond_dicts[atm_ind]
             if site["site"] in bond_dict.keys():
                 params = bond_dict[site["site"]].copy()
-                params["site_pos"] = site["position"].tolist()
+                params["site_pos"] = site["position"]
                 params["ind"] = atm_ind
                 params_list.append(params)
         site_bond_potentials[atm_ind] = params_list


### PR DESCRIPTION
This PR switches us from using ACAT's toolkit to identify site occupations and unique sites. We still use ACATs format for site information, but this allows use of site sets that are not ACAT produced. This causes Pynta to only use ACAT to identify sites if no site information is supplied. 