### PR TITLE
Calculate IRC with fmaxirc not fmaxopt

### DIFF
--- a/pynta/main.py
+++ b/pynta/main.py
@@ -490,11 +490,11 @@ class Pynta:
             #if irc_mode is "fixed" freeze all slab and conduct MolecularTSEstimate. 
             if self.irc_mode == "fixed":
                 IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
-                    "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to "+str(self.nslab)]}
+                    "run_kwargs": {"fmax" : self.fmaxirc, "steps" : 70},"constraints": ["freeze up to "+str(self.nslab)]}
 
             elif self.irc_mode == "relaxed":
                 IRC_obj_dict = {"software":self.software,"label":"prefix","socket":self.socket,"software_kwargs":self.software_kwargs,
-                    "run_kwargs": {"fmax" : self.fmaxopt, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)]}
+                    "run_kwargs": {"fmax" : self.fmaxirc, "steps" : 70},"constraints": ["freeze up to {}".format(self.freeze_ind)]}
         # if irc_mode = "skip" : do not conduct IRC
             else:
                 logger.info("Skip IRC: IRC is not conducted")


### PR DESCRIPTION
It seems that https://github.com/zadorlab/pynta/pull/45 changed the fmax used in the IRC calculation from the intended fmaxirc to fmaxopt.