### PR TITLE
Remove liblapack specification

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,6 @@ dependencies:
   - acat
   - nose
   - coverage
-  - liblapack !=3.9.0
   - pysidt >=1
   - ruamel.yaml < 0.18
   - flask =2.2.5


### PR DESCRIPTION
It looks like we are no longer getting the 21_openblas build that was causing trouble for liblapack 3.9.0 and allowing liblapack to upgrade to 3.9.0 allows us to upgrade tblite to 0.3 where it has verbosity controls that make xtb output much easier to deal with. 