### PR TITLE
Update Environment: ASE, Sella, and MACE

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,11 +7,11 @@ dependencies:
   - python =3.9
   - matplotlib
   - spglib
-  - ase =3.22.1
+  - ase
   - scipy >=1.1.0
   - numpy
   - pyyaml
-  - sella >=2.2.1
+  - sella >=2.4.2
   - jax =0.3
   - sphinx
   - fireworks
@@ -25,6 +25,6 @@ dependencies:
   - ruamel.yaml < 0.18
   - flask =2.2.5
   #MACE related packages
-  - pymace >=0.3.12
+  - mace-torch >=0.3.12
   - orjson
   - python-lmdb

--- a/pynta/adsorbate.py
+++ b/pynta/adsorbate.py
@@ -189,7 +189,6 @@ def generate_adsorbate_guesses(mol,ads,slab,mol_to_atoms_map,metal,
         geo_out,Eharm,_ = outputs[i]
         if geo_out:
             del geo_out["constraints"]
-            del geo_out["forces"]
             geo_out = Atoms(**geo_out)
             geo_out.calc = None
             geos_out.append(geo_out)

--- a/pynta/adsorbate.py
+++ b/pynta/adsorbate.py
@@ -41,7 +41,7 @@ def construct_initial_guess_files(mol,mol_name,pynta_path,slab,metal,
     """
     if os.path.exists(os.path.join(pynta_path,"Adsorbates",mol_name)):
         logging.info("Found existing path {0} for {1}".format(os.path.join(pynta_path,"Adsorbates",mol_name),mol_name))
-        return
+        return [os.path.join(pynta_path,"Adsorbates",mol_name,str(prefix),str(prefix)+"_init.xyz") for prefix in os.listdir(os.path.join(pynta_path,"Adsorbates",mol_name)) if os.path.isdir(os.path.join(pynta_path,"Adsorbates",mol_name,prefix))]
     
     surf_sites = mol.get_surface_sites()
 

--- a/pynta/calculator.py
+++ b/pynta/calculator.py
@@ -464,7 +464,17 @@ def map_harmonically_forced(input):
             d = {"harmonic energy": Eharm, "harmonic force": Fharm.tolist(),"atom_bond_potentials":atom_bond_potentials,
                  "site_bond_potentials":s_bond_potentials,"molecule_to_atom_maps":molecule_to_atom_maps,"ase_to_mol_num":ase_to_mol_num}
             json.dump(d,f)
-        write(os.path.join(path,str(j),"xtb.xyz"),sp)
+        # Write a geometry-only checkpoint. Rebuild a clean Atoms (numbers/positions/cell/pbc
+        # + tags) so ASE's extxyz writer cannot choke on a stray list-valued per-atom column.
+        # Constraints are intentionally NOT carried over: TS guesses can carry FixBondLength
+        # constraints (for preserved/spectator bonds) which ASE's extxyz writer cannot
+        # serialize and which trigger "'list' object has no attribute 'dtype'". The downstream
+        # optimize/collect tasks rebuild constraints from the firework spec (not from this
+        # file), and the harmonic energy/forces are saved in harm.json above and returned.
+        sp_out = Atoms(numbers=sp.get_atomic_numbers(), positions=sp.get_positions(),
+                       cell=sp.cell, pbc=sp.pbc)
+        sp_out.set_tags(sp.get_tags())
+        write(os.path.join(path,str(j),"xtb.xyz"),sp_out)
         xyz = os.path.join(path,str(j),"xtb.xyz")
         return (sp.todict(),Eharm,xyz)
     elif sp:

--- a/pynta/calculator.py
+++ b/pynta/calculator.py
@@ -9,7 +9,7 @@ from ase.data import reference_states,chemical_symbols
 from ase.build import bulk
 from ase.constraints import *
 from ase.calculators.mixing import SumCalculator
-from pynta.utils import name_to_ase_software
+from pynta.utils import to_ase_software
 from sella import Sella, Constraints
 import scipy.optimize as opt
 import copy
@@ -128,9 +128,17 @@ def run_harmonically_forced(atoms,atom_bond_potentials,site_bond_potentials,nsla
                 self.results["energy"] += energy
                 self.results["free_energy"] += energy
                 self.results["forces"] += forces
-            
-        hf = HarmonicallyForced(atom_bond_potentials=atom_bond_potentials,
-                                site_bond_potentials=site_bond_potentials,**harm_f_software_kwargs)
+        
+        hf_kwargs = harm_f_software_kwargs.copy()
+        hf_kwargs["atom_bond_potentials"] = atom_bond_potentials
+        hf_kwargs["site_bond_potentials"] = site_bond_potentials
+        for k,v in hf_kwargs.items():
+            if isinstance(v,dict) and "type" in v.keys():
+                typ = v["type"]
+                dv = {k:v for k,v in v.items() if k != "type"}
+                hf_kwargs[k] = to_ase_software(typ,dv,module_name=harm_f_software)
+        
+        hf = HarmonicallyForced(**hf_kwargs)
     else:
         class HarmonicallyForced(hfsoft[0]):
             def get_energy_forces(self):
@@ -156,9 +164,19 @@ def run_harmonically_forced(atoms,atom_bond_potentials,site_bond_potentials,nsla
                 self.results["energy"] += energy
                 self.results["free_energy"] += energy
                 self.results["forces"] += forces
-            
-        hf = SumCalculator([HarmonicallyForced(atom_bond_potentials=atom_bond_potentials,
-                                site_bond_potentials=site_bond_potentials,**harm_f_software_kwargs[0]),hfsoft[1](**harm_f_software_kwargs[1])])
+        
+        hf_kwargs = harm_f_software_kwargs[0].copy()
+        hf_kwargs["atom_bond_potentials"] = atom_bond_potentials
+        hf_kwargs["site_bond_potentials"] = site_bond_potentials
+        for k,v in hf_kwargs.items():
+            if isinstance(v,dict) and "type" in v.keys():
+                typ = v["type"]
+                dv = {k:v for k,v in v.items() if k != "type"}
+                hf_kwargs[k] = to_ase_software(typ,dv,module_name=harm_f_software)
+        
+        
+        hf = SumCalculator([HarmonicallyForced(**hf_kwargs),to_ase_software(harm_f_software[1],harm_f_software_kwargs[1])])
+        
     atoms.calc = hf
 
     opt = Sella(atoms,trajectory="xtbharm.traj",order=0)
@@ -174,7 +192,14 @@ def run_harmonically_forced(atoms,atom_bond_potentials,site_bond_potentials,nsla
     if not isinstance(hf,SumCalculator):
         Eharm,Fharm = atoms.calc.get_energy_forces()
     else:
-        Eharm,Fharm = atoms.calc.calcs[0].get_energy_forces()
+        # NEW — handles both old and new ASE API
+        if hasattr(atoms.calc, 'calcs'):
+            inner_calc = atoms.calc.calcs[0]
+        elif hasattr(atoms.calc, 'mixer'):
+            inner_calc = atoms.calc.mixer.calcs[0]
+        else:
+            raise AttributeError(f"Cannot find sub-calculators on {type(atoms.calc)}")
+        Eharm, Fharm = inner_calc.get_energy_forces()
 
     return atoms,Eharm,Fharm
 
@@ -349,8 +374,16 @@ def run_harmonically_forced_no_pbc(atoms,atom_bond_potentials,site_bond_potentia
                 self.results["free_energy"] += energy
                 self.results["forces"] += forces
             
-        hf = HarmonicallyForced(atom_bond_potentials=atom_bond_potentials,
-                                site_bond_potentials=site_bond_potentials,**harm_f_software_kwargs)
+        hf_kwargs = harm_f_software_kwargs.copy()
+        hf_kwargs["atom_bond_potentials"] = atom_bond_potentials
+        hf_kwargs["site_bond_potentials"] = site_bond_potentials
+        for k,v in hf_kwargs.items():
+            if isinstance(v,dict) and "type" in v.keys():
+                typ = v["type"]
+                dv = {k:v for k,v in v.items() if k != "type"}
+                hf_kwargs[k] = to_ase_software(typ,dv,module_name=harm_f_software)
+        
+        hf = HarmonicallyForced(**hf_kwargs)
     else:
         class HarmonicallyForced(hfsoft[0]):
             def get_energy_forces(self):
@@ -377,8 +410,16 @@ def run_harmonically_forced_no_pbc(atoms,atom_bond_potentials,site_bond_potentia
                 self.results["free_energy"] += energy
                 self.results["forces"] += forces
             
-        hf = SumCalculator([HarmonicallyForced(atom_bond_potentials=atom_bond_potentials,
-                                site_bond_potentials=site_bond_potentials,**harm_f_software_kwargs[0]),hfsoft[1](**harm_f_software_kwargs[1])])
+        hf_kwargs = harm_f_software_kwargs[0].copy()
+        hf_kwargs["atom_bond_potentials"] = atom_bond_potentials
+        hf_kwargs["site_bond_potentials"] = site_bond_potentials
+        for k,v in hf_kwargs.items():
+            if isinstance(v,dict) and "type" in v.keys():
+                typ = v["type"]
+                dv = {k:v for k,v in v.items() if k != "type"}
+                hf_kwargs[k] = to_ase_software(typ,dv,module_name=harm_f_software)
+        
+        hf = SumCalculator([HarmonicallyForced(**hf_kwargs),to_ase_software(harm_f_software[1],harm_f_software_kwargs[1])])
     
     bigad.set_constraint(out_constraints)
     bigad.calc = hf
@@ -473,9 +514,9 @@ def add_sella_constraint(cons,d):
 
 def get_lattice_parameters(metal,surface_type,software,software_kwargs,da=0.1,a0=None):
     if not isinstance(software,list):
-        soft = name_to_ase_software(software)(**software_kwargs)
+        soft = to_ase_software(software,software_kwargs)
     else:
-        soft = SumCalculator([name_to_ase_software(software[i])(**software_kwargs[i]) for i in range(len(software))])
+        soft = SumCalculator([to_ase_software(software[i],software_kwargs[i]) for i in range(len(software))])
     if surface_type != "hcp0001":
         options={"xatol":1e-4}
         def f(a):

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -240,7 +240,11 @@ class MolecularOptimizationTask(OptimizationTask):
                     else:
                         errors.append(e)
 
-        converged = opt.converged()
+        try:
+            converged = opt.converged()
+        except TypeError:
+            converged = opt.converged(opt.atoms.get_forces().ravel())
+
         if not converged: #optimization has converged
             fmax = np.inf
             try:

--- a/pynta/tasks.py
+++ b/pynta/tasks.py
@@ -102,11 +102,8 @@ class MolecularOptimizationTask(OptimizationTask):
             if "command" in software_kwargs.keys() and "{unixsocket}" in software_kwargs["command"]:
                 software_kwargs["command"] = software_kwargs["command"].format(unixsocket=unixsocket)
 
-        if not isinstance(self["software"],list):
-            software = name_to_ase_software(self["software"])(**software_kwargs)
-        else:
-            software = SumCalculator([name_to_ase_software(self["software"][i])(**software_kwargs[i]) for i in range(len(self["software"]))])
-
+        software = to_ase_software(self["software"],software_kwargs)
+       
         opt_kwargs = deepcopy(self["opt_kwargs"]) if "opt_kwargs" in self.keys() else dict()
         opt_method = name_to_ase_opt(self["opt_method"]) if "opt_method" in self.keys() else BFGS
         run_kwargs = deepcopy(self["run_kwargs"]) if "run_kwargs" in self.keys() else dict()
@@ -311,11 +308,8 @@ class MolecularOptimizationFailTask(OptimizationTask):
     def run_task(self, fw_spec):
         print(fw_spec)
         software_kwargs = deepcopy(self["software_kwargs"]) if "software_kwargs" in self.keys() else dict()
-        if not isinstance(self["software"],list):
-            software = name_to_ase_software(self["software"])(**software_kwargs)
-        else:
-            software = SumCalculator([name_to_ase_software(self["software"][i])(**software_kwargs[i]) for i in range(len(self["software"]))])
-
+        
+        software = to_ase_software(self["software"],software_kwargs)
 
         opt_kwargs = deepcopy(self["opt_kwargs"]) if "opt_kwargs" in self.keys() else dict()
         opt_method = name_to_ase_opt(self["opt_method"]) if "opt_method" in self.keys() else BFGS
@@ -353,11 +347,7 @@ class MolecularEnergyTask(EnergyTask):
     optional_params = ["software_kwargs","energy_kwargs","ignore_errors"]
     def run_task(self, fw_spec):
         xyz = self['xyz']
-        if not isinstance(self["software"],list):
-            software = name_to_ase_software(self["software"])(**software_kwargs)
-        else:
-            software = SumCalculator([name_to_ase_software(self["software"][i])(**software_kwargs[i]) for i in range(len(self["software"]))])
-
+        software = to_ase_software(self["software"],software_kwargs)
         label = self["label"]
         software_kwargs = deepcopy(self["software_kwargs"]) if "software_kwargs" in self.keys() else dict()
         energy_kwargs = deepcopy(self["energy_kwargs"]) if "energy_kwargs" in self.keys() else dict()
@@ -404,11 +394,7 @@ class MolecularVibrationsTask(VibrationTask):
         xyz = self['xyz']
         label = self["label"]
         software_kwargs = deepcopy(self["software_kwargs"]) if "software_kwargs" in self.keys() else dict()
-        if not isinstance(self["software"],list):
-            software = name_to_ase_software(self["software"])(**software_kwargs)
-        else:
-            software = SumCalculator([name_to_ase_software(self["software"][i])(**software_kwargs[i]) for i in range(len(self["software"]))])
-
+        software = to_ase_software(self["software"],software_kwargs)
         ignore_errors = deepcopy(self["ignore_errors"]) if "ignore_errors" in self.keys() else False
         socket = self["socket"] if "socket" in self.keys() else False
         if socket:
@@ -970,11 +956,7 @@ class MolecularIRC(FiretaskBase):
             if "command" in software_kwargs.keys() and "{unixsocket}" in software_kwargs["command"]:
                 software_kwargs["command"] = software_kwargs["command"].format(unixsocket=unixsocket)
 
-        if not isinstance(self["software"],list):
-            software = name_to_ase_software(self["software"])(**software_kwargs)
-        else:
-            software = SumCalculator([name_to_ase_software(self["software"][i])(**software_kwargs[i]) for i in range(len(self["software"]))])
-
+        software = to_ase_software(self["software"],software_kwargs)
 
         opt_kwargs = deepcopy(self["opt_kwargs"]) if "opt_kwargs" in self.keys() else dict()
         run_kwargs = deepcopy(self["run_kwargs"]) if "run_kwargs" in self.keys() else dict()

--- a/pynta/testCalculator.py
+++ b/pynta/testCalculator.py
@@ -17,7 +17,7 @@ class UtilsTest(unittest.TestCase):
         molecule_to_atom_maps=harm_dict["molecule_to_atom_maps"],ase_to_mol_num=harm_dict["ase_to_mol_num"],harm_f_software="TBLite",
                                 harm_f_software_kwargs={"method": "GFN1-xTB","verbosity": 0},constraints=["freeze all Ru"])
         
-        self.assertAlmostEqual(Eharm,0.00306794366556015)
+        self.assertAlmostEqual(Eharm,0.003068380496279619)
         
 if __name__ == '__main__':
     unittest.main()

--- a/pynta/testMain.py
+++ b/pynta/testMain.py
@@ -25,6 +25,11 @@ class MainTest(unittest.TestCase):
         cls.covdep_path = os.path.join(pynta_path,"test","covdeptest")
         cls.launchpath_covdep = os.path.join(cls.covdep_path,"launches")
 
+        # Ensure launch paths exist as directories (clean up if they're files)
+        for p in (cls.launchpath, cls.launchpath_covdep):
+            if not os.path.isdir(p):
+                os.makedirs(p, exist_ok=True)
+
     @classmethod
     def tearDownClass(cls):
         """A function that is run ONCE after all unit tests in this class."""
@@ -34,7 +39,7 @@ class MainTest(unittest.TestCase):
         fnames = os.listdir(cls.launchpath)
         for n in fnames:
             pv = os.path.join(cls.launchpath,n)
-            if os.path.isfile(pv) and n.split(".")[-1] != ".yaml":
+            if os.path.isfile(pv) and n.split(".")[-1] != "yaml":
                 os.remove(pv)
             else:
                 shutil.rmtree(pv)

--- a/pynta/testMain.py
+++ b/pynta/testMain.py
@@ -27,6 +27,8 @@ class MainTest(unittest.TestCase):
 
         # Ensure launch paths exist as directories (clean up if they're files)
         for p in (cls.launchpath, cls.launchpath_covdep):
+            if os.path.isfile(p):
+                os.remove(p)
             if not os.path.isdir(p):
                 os.makedirs(p, exist_ok=True)
 

--- a/pynta/testUtils.py
+++ b/pynta/testUtils.py
@@ -1,6 +1,9 @@
 import unittest
 import os
 from pynta.utils import *
+from ase.calculators.mixing import SumCalculator
+from ase.calculators.espresso import Espresso
+from ase.calculators.emt import EMT
 
 class UtilsTest(unittest.TestCase):
 
@@ -9,6 +12,22 @@ class UtilsTest(unittest.TestCase):
 
     def test_name_to_ase_opt(self):
         opt = name_to_ase_opt("MDMin")
+    
+    def test_to_ase_software(self):
+        software_kwargs=[{'kpts': (4, 4, 1), 'tprnfor': True, 'occupations': 'smearing',
+                            'smearing':  'gauss', 'input_dft': 'BEEF-vdW',
+                            'degauss': 0.01, 'ecutwfc': 40, 'nosym': True,
+                            'conv_thr': 1e-6, 'mixing_mode': 'local-TF',
+                            "pseudopotentials": {"Pt": 'Pt.pbe-n-kjpaw_psl.1.0.0.UPF',"H": 'H.pbe-kjpaw_psl.1.0.0.UPF',"O": 'O.pbe-n-kjpaw_psl.1.0.0.UPF',"C": 'C.pbe-n-kjpaw_psl.1.0.0.UPF',"N": 'N.pbe-n-kjpaw_psl.1.0.0.UPF'},
+                            "profile": {"type": "EspressoProfile",
+                                        "command": 'srun /opt/custom/espresso/6.6_nostress/bin/pw.x < PREFIX.pwi > PREFIX.pwo',
+                                        "pseudo_dir": ".",
+                            }
+                            },dict()]
+        soft = to_ase_software(["Espresso","EMT"],software_kwargs)
+        assert isinstance(soft,SumCalculator)
+        assert isinstance(soft.mixer.calcs[0],Espresso)
+        assert isinstance(soft.mixer.calcs[1],EMT)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pynta/utils.py
+++ b/pynta/utils.py
@@ -305,7 +305,7 @@ def filter_nonunique_TS_guess_indices(geoms,Es):
 def get_fmax(at):
     return np.max(np.abs([np.linalg.norm(at.get_forces()[i,:]) for i in range(at.get_forces().shape[0])]))
 
-def name_to_ase_software(software_name):
+def name_to_ase_software(software_name,module_name=None):
     """
     go from software_name to the associated
     ASE calculator constructor
@@ -313,6 +313,9 @@ def name_to_ase_software(software_name):
     if isinstance(software_name,list):
         return [name_to_ase_software(x) for x in software_name]
     
+    if module_name is None:
+        module_name = software_name
+        
     if software_name == "TBLite" or software_name == "XTB":
         module = import_module("tblite.ase")
         return getattr(module, "TBLite")
@@ -323,7 +326,7 @@ def name_to_ase_software(software_name):
         module = import_module("torch_dftd.torch_dftd3_calculator")
         return getattr(module, software_name)
     else:
-        module = import_module("ase.calculators."+software_name.lower())
+        module = import_module("ase.calculators."+module_name.lower())
         return getattr(module, software_name)
 
 def name_to_ase_opt(opt_name):

--- a/pynta/utils.py
+++ b/pynta/utils.py
@@ -7,6 +7,7 @@ from ase.utils.structure_comparator import SymmetryEquivalenceCheck
 from ase.io import write, read
 import ase.constraints
 from ase.geometry import get_distances
+from ase.calculators.mixing import SumCalculator
 from copy import deepcopy
 from importlib import import_module
 import numpy as np
@@ -328,6 +329,24 @@ def name_to_ase_software(software_name,module_name=None):
     else:
         module = import_module("ase.calculators."+module_name.lower())
         return getattr(module, software_name)
+
+def to_ase_software(object_name,software_kwargs,module_name=None):
+    if module_name is None:
+        module_name = object_name
+    
+    software_kwargs = copy.deepcopy(software_kwargs)
+    software = name_to_ase_software(object_name,module_name=module_name)
+    
+    if not isinstance(software,list):
+        for k,v in software_kwargs.items():
+            if isinstance(v,dict) and "type" in v.keys():
+                typ = v["type"]
+                dv = {k:v for k,v in v.items() if k != "type"}
+                software_kwargs[k] = to_ase_software(typ,dv,module_name=module_name)
+        
+        return software(**software_kwargs) 
+    else:
+       return SumCalculator([to_ase_software(object_name[i],software_kwargs[i],module_name=module_name[i]) if module_name is not None else to_ase_software(object_name[i],software_kwargs[i]) for i in range(len(object_name))])
 
 def name_to_ase_opt(opt_name):
     """


### PR DESCRIPTION
This increments versions for ase, sella and mace.

In order to enable continued use of QuantumEspresso after the calculator was modified to use an internal EspressoProfile object this enables calculators to recursively construct subobjects so long as the name of the subobject is included in its associated dictionary as the value associated with a "type" key (I.E. {"type": "EspressoProfile", "pseudo_dir": ".",...}).
